### PR TITLE
Elimina el estado 'pending/confirmando' al generar el link de pago

### DIFF
--- a/docs/arquitectura/suscripciones.md
+++ b/docs/arquitectura/suscripciones.md
@@ -156,21 +156,20 @@ if (existingPlan) return;   // createStore ya lo inicializó → no-op
 createSubscription (Cloud Function)
    │ 1. valida auth (owner por uid, o admin vía /admins/{uid})
    │ 2. valida plan === "pro" y email
-   │ 3. rechaza si ya hay un PreApproval "pending" para el mismo plan
+   │ 3. si había un intento anterior sin pagar (billing.subscriptionId y la tienda
+   │    NO está en un plan pago activo) → cancela ese PreApproval viejo en MP
+   │    (PUT /preapproval/{id} status=cancelled, best-effort). NO bloquea regenerar.
    │ 4. crea PreApproval en MP:
    │       external_reference = "{storeId}:pro"
    │       auto_recurring     = { frequency: 1, frequency_type: "months", amount: 15000, ARS }
-   │       status             = "pending"
+   │       status             = "pending"   ◄── estado del PreApproval en MP, NO de la tienda
    │       back_url           = {APP_URL}/suscripcion/confirmacion
-   │ 5. guarda en Firestore (SIN tocar plan/active/endDate del trial vigente):
+   │ 5. guarda SOLO datos de referencia (SIN tocar plan/active/endDate/paymentStatus):
    │       subscription.billing.subscriptionId = preapproval.id
    │       subscription.billing.provider       = "mercadopago"
    │       subscription.billing.payerEmail     = userEmail
    │       subscription.billing.autoRenew      = true
-   │       subscription.billing.pendingPlan    = "pro"   ◄── plan contratado, aún no confirmado
-   │       subscription.paymentStatus          = "pending"
-   │       subscription.cancelAtPeriodEnd      = false
-   │       subscription.graceUntil             = null
+   │       subscription.billing.pendingPlan    = "pro"   ◄── plan contratado, lo promueve el webhook
    │ 6. devuelve { initPoint, subscriptionId }
    ▼
 [Frontend redirige a initPoint — usuario paga en MercadoPago]
@@ -189,13 +188,13 @@ MP redirige a  /suscripcion/confirmacion?preapproval_id=...
    │ AutoRedirect → /dashboard/subscription (router.refresh para releer estado)
 ```
 
-**Diseño importante — `pendingPlan`:** mientras el pago no se confirma, el plan **real** sigue siendo `trial` (o el que estuviera). El plan contratado vive en `billing.pendingPlan`. Así, si el usuario abandona el checkout, **no pierde el acceso del trial** y no queda con un `plan: "pro"` sin pagar. El plan se promueve recién cuando llega el evento `authorized`.
+**Diseño importante — generar el link NO cambia el estado de la tienda:** `createSubscription` solo escribe datos de referencia en `billing.*`. **No** toca `plan`, `active`, `endDate` ni `paymentStatus`. El plan real sigue siendo `trial` (o el que estuviera) con su lógica normal de vencimiento, y el plan contratado vive en `billing.pendingPlan`. El **webhook de MP es la única fuente de verdad**: el plan se promueve a `pro` recién con el evento `authorized`.
 
-### 5.2 Estado intermedio: pago pendiente
+Esto evita el bug del "estado confirmando eterno": si el usuario solo genera el link para ver el precio y vuelve sin pagar, la tienda **no queda en `pending`**, no se bloquea la regeneración del link, y el trial vence normalmente (antes, el `paymentStatus: "pending"` dejaba la tienda colgada en "Confirmando..." y mantenía el trial vivo indefinidamente).
 
-Mientras `paymentStatus === "pending"` y existe `billing.pendingPlan`, la UI muestra la card naranja "Pago en proceso" y el dashboard **mantiene el acceso** (`isPendingPayment` en el layout). El usuario puede:
-- "Verificar estado ahora" (refresca el server component).
-- "Cancelar intento" (llama `cancelSubscription`).
+### 5.2 Volver sin pagar / regenerar el link
+
+Como generar el link no pone a la tienda en espera, **no hay un estado intermedio "pago en proceso"**. Si el usuario vuelve sin pagar, sigue viendo su plan actual (trial) y el botón "Suscribirme" disponible. Si vuelve a generar el link, `createSubscription` cancela el PreApproval anterior en MP (best-effort) y crea uno nuevo. Un PreApproval abandonado en MP es inofensivo: aunque el usuario pagara un link viejo, el webhook resuelve la tienda por `external_reference` y promueve el plan igual.
 
 ---
 
@@ -267,11 +266,7 @@ Si MP cancela el PreApproval (ej: falta de pago persistente), envía `subscripti
 y para cada store aplica (recordar: **no existe `plan: "free"`** — suspender = `active: false` manteniendo el plan):
 
 ```
-┌─ paymentStatus="pending" + pendingPlan  → SKIP (pago en proceso) ───┐
-│     No suspender aunque el trial/período haya vencido: el pago MP    │
-│     puede tardar (Rapipago/Pago Fácil quedan "pending" por días).    │
-│                                                                      │
-├─ plan === "trial"  ── Camino TRIAL (prueba agotada sin contratar) ──┤
+┌─ plan === "trial"  ── Camino TRIAL (prueba agotada sin contratar) ──┐
 │     • active=false, paymentStatus=expired                            │
 │     • notificación "trial_expired"  · SIN gracia, SIN tocar MP       │
 │     → corta acceso al dashboard Y al catálogo público               │
@@ -307,18 +302,18 @@ No hay un middleware único. **Dos gates independientes** leen `subscription`:
 ### 9.1 Dashboard — `app/dashboard/layout.tsx` (Server Component)
 
 ```typescript
-const isPro            = subscription?.plan === 'pro'   && subscription?.active;
-const isOnTrial        = subscription?.plan === 'trial' && subscription?.active;
-const isPendingPayment = subscription?.paymentStatus === 'pending' && !!subscription?.billing?.pendingPlan;
+const isPro     = subscription?.plan === 'pro'   && subscription?.active;
+const isOnTrial = subscription?.plan === 'trial' && subscription?.active;
 
 const hasValidAccess =
   isPro ||
   (isOnTrial && endDateMs > now) ||
-  isPendingPayment ||
   (graceUntilMs > now);
 
 if (!hasValidAccess) return <AccessDeniedView ... />;   // ← pantalla "Acceso Suspendido"
 ```
+
+> Generar un link de pago **no** otorga acceso por sí solo (ya no existe un `isPendingPayment`). El acceso sale del trial vigente o del plan `pro` activo; el plan se vuelve `pro` recién cuando el webhook confirma el pago.
 
 El acceso requiere `active: true` en todos los casos (más `endDate` vigente para el trial). Como **no existe `plan: "free"`**, una cuenta suspendida (`active: false`) nunca recupera acceso por downgrade: queda en "Acceso Suspendido" hasta que contrate/renueve.
 
@@ -340,8 +335,9 @@ Solo mira `active`. **No** considera `endDate` ni `plan`.
 | `pro`, `active:true` | ✅ | ✅ | Pago al día |
 | `pro`, `active:true`, `cancelAtPeriodEnd:true`, `endDate` futura | ✅ | ✅ | Cancelado pero vigente |
 | `pro`, `active:false` (paused/cancelled/expired) | ❌ **AccessDenied** | ❌ | Suspendido (mantiene `plan:"pro"`) |
-| `pending` + `pendingPlan` | ✅ | depende de `active` | Pago en proceso |
 | en gracia (`graceUntil` futura) | ✅ | ✅ | 3 días para renovar |
+
+> Generar un link de pago no crea un estado de acceso propio: el acceso lo determina el plan vigente (trial/pro), como en las filas de arriba. `billing.pendingPlan` solo indica el plan que el webhook promoverá al confirmarse el pago.
 
 > Tras los cambios de junio 2026, **dashboard y catálogo quedan consistentes**: una cuenta suspendida (`active:false`) está bloqueada en ambos lados, sin importar si el plan es `trial` o `pro`. La pantalla "Acceso Suspendido" cubre todos los casos de suspensión.
 

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -46,16 +46,16 @@ export default async function Layout({ children }: { children: React.ReactNode }
   const endDateMs = subscription?.endDate ? new Date(subscription.endDate as string).getTime() : 0;
   const graceUntilMs = subscription?.graceUntil ? new Date(subscription.graceUntil as string).getTime() : 0;
 
-  // Pago iniciado pero aún no confirmado: mantener acceso para no bloquear al usuario durante el proceso
-  const isPendingPayment = subscription?.paymentStatus === 'pending' && !!subscription?.billing?.pendingPlan;
-
   // Tiene acceso si: es Pro activo, O está en Trial vigente (no venció),
-  // O tiene un pago en proceso, O está en período de gracia. No existe plan "free":
-  // un trial vencido o un pro suspendido quedan con active=false → sin acceso.
+  // O está en período de gracia. No existe plan "free": un trial vencido o un pro
+  // suspendido quedan con active=false → sin acceso.
+  //
+  // Generar un link de pago NO otorga acceso por sí solo: el plan se promueve a "pro"
+  // recién cuando el webhook de MP confirma el pago (authorized). Mientras tanto el
+  // usuario conserva el acceso de su trial vigente si todavía no venció.
   const hasValidAccess =
     isPro ||
     (isOnTrial && endDateMs > now) ||
-    isPendingPayment ||
     (graceUntilMs > now);
 
   if (!hasValidAccess) {

--- a/src/features/dashboard/modules/store-settings/components/SubscriptionPageClient.tsx
+++ b/src/features/dashboard/modules/store-settings/components/SubscriptionPageClient.tsx
@@ -42,7 +42,6 @@ import {
   HeadphonesIcon,
   AlertCircle,
   RefreshCw,
-  XCircle,
   ArrowRight
 } from 'lucide-react';
 
@@ -78,7 +77,6 @@ function getPaymentStatusLabel(
   }
   switch (status) {
     case 'authorized': return { label: 'Activo', variant: 'default' };
-    case 'pending':    return { label: 'Pago pendiente', variant: 'secondary' };
     case 'paused':     return { label: 'Pausado', variant: 'secondary' };
     case 'cancelled':  return { label: 'Cancelado', variant: 'destructive' };
     case 'expired':    return { label: 'Vencido', variant: 'destructive' };
@@ -118,9 +116,6 @@ export default function SubscriptionPageClient({
 
   const isPro = subscription.plan === 'pro' && subscription.active;
   const isOnTrial = subscription.plan === 'trial' && subscription.active;
-  // paymentStatus="pending" con pendingPlan indica que el usuario inició el pago pero aún no lo confirmó.
-  // El plan real se promueve recién cuando llega el webhook "authorized".
-  const isPendingConfirmation = subscription.paymentStatus === 'pending' && !!subscription.billing?.pendingPlan;
 
   const endDateMs = subscription.endDate
     ? (subscription.endDate as any).toDate
@@ -322,13 +317,14 @@ export default function SubscriptionPageClient({
 
       {/* Banners */}
       <div className="space-y-4">
-        {returnedPreapprovalId && isPendingConfirmation && (
+        {returnedPreapprovalId && !isPro && (
           <Alert className="border-blue-200 bg-blue-50/80 shadow-sm">
             <RefreshCw className="h-5 w-5 text-blue-600" />
-            <AlertTitle className="text-blue-800 font-semibold">Confirmando pago</AlertTitle>
+            <AlertTitle className="text-blue-800 font-semibold">¿Completaste el pago?</AlertTitle>
             <AlertDescription className="text-blue-700 mt-1">
-              MercadoPago está verificando tu transacción. Esto puede demorar unos minutos.
-              Recargá la página en un momento para ver el estado actualizado.
+              Si pagaste, tu plan Profesional se activará automáticamente cuando MercadoPago
+              nos confirme la transacción (puede demorar unos minutos). Si solo querías ver el
+              precio, no pasa nada: seguís con tu plan actual.
             </AlertDescription>
           </Alert>
         )}
@@ -350,7 +346,7 @@ export default function SubscriptionPageClient({
         <div className="lg:col-span-7 space-y-6">
           
           {/* Card del plan Pro */}
-          {!isPro && !isPendingConfirmation && !isCancelledActive && (
+          {!isPro && !isCancelledActive && (
             <Card className="border-purple-200 bg-gradient-to-br from-purple-50 to-white shadow-md overflow-hidden relative">
               <div className="absolute top-0 right-0 p-4 opacity-5 pointer-events-none">
                 <Crown className="w-32 h-32 text-purple-900" />
@@ -436,78 +432,6 @@ export default function SubscriptionPageClient({
                       Renovación automática. Podés cancelar en cualquier momento.
                     </p>
                   </div>
-                </div>
-              </CardContent>
-            </Card>
-          )}
-
-          {/* Pending State */}
-          {isPendingConfirmation && (
-            <Card className="border-orange-200 bg-gradient-to-br from-orange-50 to-white shadow-md">
-              <CardHeader>
-                <div className="flex items-center gap-3">
-                  <div className="w-10 h-10 rounded-full bg-orange-100 flex items-center justify-center">
-                    <RefreshCw className="w-5 h-5 text-orange-600 animate-spin" />
-                  </div>
-                  <div>
-                    <CardTitle className="text-orange-900">Pago en proceso</CardTitle>
-                    <CardDescription className="text-orange-700/80">
-                      Estamos esperando la confirmación de MercadoPago
-                    </CardDescription>
-                  </div>
-                </div>
-              </CardHeader>
-              <CardContent className="space-y-4 text-orange-800">
-                <p className="text-sm">
-                  Tu pago fue enviado y está siendo procesado. Una vez confirmado, tu plan Profesional quedará activo automáticamente.
-                  Este proceso puede demorar algunos minutos.
-                </p>
-                <div className="flex flex-col sm:flex-row gap-3 pt-2">
-                  <Button
-                    type="button"
-                    className="w-full sm:w-auto bg-orange-600 hover:bg-orange-700 text-white"
-                    onClick={refreshSubscriptionStatus}
-                    disabled={checkingWebhook}
-                  >
-                    <RefreshCw className={cn("w-4 h-4 mr-2", checkingWebhook && "animate-spin")} />
-                    {checkingWebhook ? 'Verificando...' : 'Verificar estado ahora'}
-                  </Button>
-                  
-                  <AlertDialog>
-                    <AlertDialogTrigger asChild>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        className="w-full sm:w-auto border-orange-200 text-orange-700 hover:bg-orange-100"
-                        disabled={cancellingSubscription}
-                      >
-                        {cancellingSubscription ? (
-                          <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                        ) : (
-                          <XCircle className="w-4 h-4 mr-2" />
-                        )}
-                        Cancelar intento
-                      </Button>
-                    </AlertDialogTrigger>
-                    <AlertDialogContent>
-                      <AlertDialogHeader>
-                        <AlertDialogTitle>¿No completaste el pago?</AlertDialogTitle>
-                        <AlertDialogDescription>
-                          Si no llegaste a pagar o querés intentarlo de nuevo, podés cancelar
-                          este intento y empezar desde cero. No se realizó ningún cobro.
-                        </AlertDialogDescription>
-                      </AlertDialogHeader>
-                      <AlertDialogFooter>
-                        <AlertDialogCancel>Volver</AlertDialogCancel>
-                        <AlertDialogAction
-                          onClick={handleCancelSubscription}
-                          className="bg-red-600 hover:bg-red-700 text-white"
-                        >
-                          Sí, cancelar intento
-                        </AlertDialogAction>
-                      </AlertDialogFooter>
-                    </AlertDialogContent>
-                  </AlertDialog>
                 </div>
               </CardContent>
             </Card>
@@ -629,7 +553,7 @@ export default function SubscriptionPageClient({
           )}
           
           {/* Proceso Explicativo (Solo si no es Pro o está en Trial) */}
-          {(!isPro || isOnTrial) && !isPendingConfirmation && !isCancelledActive && (
+          {(!isPro || isOnTrial) && !isCancelledActive && (
             <Card className="border-gray-200 shadow-sm bg-gray-50/50">
               <CardHeader>
                 <CardTitle className="text-lg text-gray-800">Cómo funciona</CardTitle>
@@ -694,7 +618,7 @@ export default function SubscriptionPageClient({
                     'text-lg font-bold',
                     (isPro || isCancelledActive) ? 'text-purple-600' : 'text-gray-900'
                   )}>
-                    {isPro || isCancelledActive || isPendingConfirmation
+                    {isPro || isCancelledActive
                       ? 'Profesional'
                       : isOnTrial
                       ? 'Período de prueba'
@@ -711,12 +635,12 @@ export default function SubscriptionPageClient({
                       paymentStatusInfo.variant === 'secondary' && !isCancelledActive && 'bg-orange-100 text-orange-800 hover:bg-orange-100',
                     )}
                   >
-                    {subscription.paymentStatus === 'pending' ? 'Confirmando...' : paymentStatusInfo.label}
+                    {paymentStatusInfo.label}
                   </Badge>
                 </div>
               </div>
 
-              {nextPaymentDate && (isPro || isPendingConfirmation || isCancelledActive) && (
+              {nextPaymentDate && (isPro || isCancelledActive) && (
                 <div className="bg-gray-50 rounded-lg p-3 flex items-center justify-between border border-gray-100">
                   <div className="flex items-center gap-2.5">
                     <Calendar className="w-4 h-4 text-gray-400" />


### PR DESCRIPTION
Generar el link de MercadoPago ya no pone la tienda en modo espera: el webhook es la única fuente de verdad. La UI deja de mostrar 'Confirmando pago' / 'Cancelar intento' y el layout no otorga acceso por pendingPlan. Esto evita que una tienda quede colgada en 'confirmando' cuando el usuario genera el link y vuelve sin pagar, y deja regenerar el link sin bloqueos.

## Qué cambia
-

## Por qué
-

## Cómo probar
- Pasos, datos de prueba, capturas.

## Checklist
- [ ] Lint/Tipos/Tests OK
- [ ] No incluye secretos ni credenciales
- [ ] Docs/README actualizados si aplica
