### PR TITLE
docs(negocio): actualizar features, sistema de diseno y numeracion

### DIFF
--- a/docs/negocio/analisis-general.md
+++ b/docs/negocio/analisis-general.md
@@ -1,6 +1,6 @@
 # 📊 Análisis y Contexto General del Sistema
 
-> **Actualizado:** 2026-06-12 · Documento académico/funcional de alto nivel.
+> **Actualizado:** 2026-06-15 · Documento académico/funcional de alto nivel.
 > Para el alcance funcional fiel del producto, la fuente de verdad es
 > [contexto-producto.md](contexto-producto.md).
 
@@ -18,7 +18,7 @@ Desarrollar un sistema modular, escalable y eficiente que permita a pequeños y 
 ## 🎯 Objetivos Específicos
 
 - Brindar una interfaz intuitiva para la carga, edición y consulta de ventas y productos.
-- Facilitar el seguimiento de pedidos y estado de entregas en tiempo real.
+- Facilitar la recepción y el registro ordenado de pedidos provenientes del catálogo.
 - Permitir la creación de reportes financieros automáticos (PDF/Excel) con exportación.
 - Centralizar el catálogo de productos, con soporte para imágenes y variantes.
 - Permitir a los clientes realizar pedidos mediante canales digitales (ej: WhatsApp).
@@ -85,12 +85,14 @@ Con esta implementación, se busca ofrecer un servicio accesible y eficiente que
 ### ✅ Funcionalidades incluidas
 
 - Registro, edición y consulta de productos (con variantes/extras con precio).
+- Organización de productos en categorías y subcategorías (2 niveles) con orden personalizable que define cómo aparecen en la tienda.
+- Importación masiva de productos desde Excel (.xlsx), con creación automática de categorías/subcategorías/tags y vista previa.
 - Onboarding guiado para configurar la tienda paso a paso.
 - Formulario de ventas con validación y cálculo automático.
 - Generación de reportes y exportación a PDF / Excel.
 - Catálogo online con posibilidad de compartir por WhatsApp.
 - Menú QR.
-- Estados de venta: pendiente, confirmada, enviada, entregada, cancelada.
+- Registro de ventas sin flujo de estados (se cierran y se almacenan), con su origen: local, web o WhatsApp.
 - Creación de usuarios y autenticación (email/password y Google).
 - Selección de métodos de pago y entrega.
 - Interfaz adaptable (responsive, mobile-first).
@@ -100,7 +102,6 @@ Con esta implementación, se busca ofrecer un servicio accesible y eficiente que
 ### 🔜 Funcionalidades futuras (visión)
 
 - Soporte multitienda bajo una misma cuenta.
-- Carga masiva de productos (CSV / Excel).
 - Más personalización de la tienda.
 - Dominio propio del comercio.
 

--- a/docs/negocio/casos-de-uso.md
+++ b/docs/negocio/casos-de-uso.md
@@ -1,3 +1,8 @@
+# 🧩 Casos de Uso — TuTiendaWeb
+
+> **Actualizado:** 2026-06-15. Casos de uso por módulo, con numeración correlativa por prefijo (`CU-AUTH`, `CU-PROD`, `CU-SALE`, `CU-ORDER`, `CU-STORE`, `CU-REPORT`).
+
+---
 
 ## 👥 Módulo: Autenticación
 
@@ -72,7 +77,7 @@
 |📋 **Descripción**|Permite añadir un nuevo producto al sistema para su publicación en la tienda.|
 |📌 **Precondición**|El usuario debe estar en el panel autenticado.|
 |🎯 **Postcondición**|El producto queda guardado en la base de datos y visible en el listado.|
-|📑 **Flujo principal**|1. Accede a “Productos” y hace clic en “Agregar”.2. Completa campos: nombre, precio, stock, categoría, imagen.3. Presiona “Guardar”.4. El sistema valida los datos.5. Si todo está correcto, guarda y muestra confirmación.|
+|📑 **Flujo principal**|1. Accede a “Productos” y hace clic en “Agregar”.2. Completa campos: nombre, precio, categoría, subcategoría, imagen.3. Presiona “Guardar”.4. El sistema valida los datos.5. Si todo está correcto, guarda y muestra confirmación.|
 |⚠️ **Flujos alternativos**|- 2a: Imagen no válida → se muestra error.- 4a: Campos vacíos o con formato incorrecto → se bloquea envío.- 5a: Si hay error de red/backend → se ofrece reintentar.|
 
 ---
@@ -114,7 +119,7 @@
 |📋 **Descripción**|Muestra todos los productos disponibles en una tabla filtrable y ordenable.|
 |📌 **Precondición**|Debe haber productos registrados.|
 |🎯 **Postcondición**|Se presenta la lista completa para gestionar.|
-|📑 **Flujo principal**|1. Entra a sección “Productos”.2. El sistema carga listado.3. Puede filtrar por nombre, categoría o stock.4. Ordenar columnas.|
+|📑 **Flujo principal**|1. Entra a sección “Productos”.2. El sistema carga listado.3. Puede filtrar por nombre, categoría o subcategoría.4. Ordenar columnas.|
 |⚠️ **Flujos alternativos**|- 2a: No hay productos → mensaje de lista vacía.|
 
 ---
@@ -162,6 +167,34 @@
 
 ---
 
+### 🗂️ CU-PROD-08 – Gestionar Categorías y Subcategorías
+
+| Ítem | Descripción |
+|---|---|
+| 🆔 **Código** | CU-PROD-08 |
+| 👤 **Actor** | Dueño de Tienda |
+| 📋 **Descripción** | Permite crear, editar y eliminar categorías y subcategorías para organizar el catálogo en una jerarquía de 2 niveles (categoría principal → subcategoría). |
+| 📌 **Precondición** | El usuario debe estar autenticado en el panel. |
+| 🎯 **Postcondición** | La categoría/subcategoría queda guardada (con su `parentId`: `null` si es principal, o el id de la categoría padre si es subcategoría) y disponible para asignar a productos. |
+| 📑 **Flujo principal** | 1. Accede al gestor de categorías desde Productos. 2. Crea una categoría principal (nombre, descripción opcional). 3. Opcionalmente crea una subcategoría eligiendo su categoría padre. 4. Puede editar el nombre o activar/desactivar. 5. El sistema valida y persiste; el slug se deriva del nombre. |
+| ⚠️ **Flujos alternativos** | 2a: Nombre vacío o demasiado corto → error de validación. 3a: Intentar anidar más de 2 niveles → no permitido (una subcategoría no puede ser padre). 4a: Eliminar una categoría con productos/subcategorías → se pide confirmación. |
+
+---
+
+### ↕️ CU-PROD-09 – Ordenar Categorías y Subcategorías
+
+| Ítem | Descripción |
+|---|---|
+| 🆔 **Código** | CU-PROD-09 |
+| 👤 **Actor** | Dueño de Tienda |
+| 📋 **Descripción** | Permite definir manualmente el orden en que las categorías y subcategorías aparecen en la tienda pública, arrastrando para reordenar. |
+| 📌 **Precondición** | Deben existir al menos dos categorías (o subcategorías de un mismo padre) para reordenar. |
+| 🎯 **Postcondición** | Se persiste el campo `order` de cada categoría/subcategoría y la tienda pública refleja el nuevo orden. |
+| 📑 **Flujo principal** | 1. Accede al gestor de categorías. 2. Arrastra una categoría/subcategoría a su nueva posición (se reordena un nivel a la vez). 3. El sistema guarda el nuevo `order` en lote. 4. La tienda pública muestra las categorías en ese orden. |
+| ⚠️ **Flujos alternativos** | 3a: Error al guardar el reordenamiento → se notifica y se mantiene el orden anterior. |
+
+---
+
 ## 🧾 Módulo: Gestión de Ventas
 
 ---
@@ -172,11 +205,11 @@
 |---|---|
 |🆔 **Código**|CU-SALE-01|
 |👤 **Actor**|Dueño de Tienda|
-|📋 **Descripción**|Permite registrar una venta asociando productos, cantidades, cliente, método de pago y estado.|
+|📋 **Descripción**|Permite registrar una venta asociando productos, cantidades, cliente, método de pago y entrega. La venta se cierra y se almacena (no tiene flujo de estados).|
 |📌 **Precondición**|Deben existir productos en el sistema.|
 |🎯 **Postcondición**|La venta queda registrada con su resumen de datos.|
 |📑 **Flujo principal**|1. Accede al módulo de ventas.2. Hace clic en “Nueva venta”.3. Selecciona productos y cantidades.4. Agrega datos del cliente (opcional).5. Selecciona método de pago y entrega.6. Se calcula automáticamente el total.7. Presiona “Guardar”.|
-|⚠️ **Flujos alternativos**|- 3a: No hay stock suficiente → mostrar advertencia.- 4a: Cliente sin datos válidos → mostrar error.- 7a: Fallo en guardar → notificar.|
+|⚠️ **Flujos alternativos**|- 4a: Cliente sin datos válidos → mostrar error.- 7a: Fallo en guardar → notificar.|
 
 ---
 
@@ -228,7 +261,7 @@
 |---|---|
 |🆔 **Código**|CU-SALE-05|
 |👤 **Actor**|Dueño de Tienda|
-|📋 **Descripción**|Permite visualizar ventas por fecha, cliente, total, estado.|
+|📋 **Descripción**|Permite visualizar ventas por fecha, cliente, total, método de pago, método de entrega y origen.|
 |📌 **Precondición**|Debe haber ventas registradas.|
 |🎯 **Postcondición**|Se muestran solo las coincidencias filtradas.|
 |📑 **Flujo principal**|1. Ingresa a historial de ventas.2. Aplica filtros por campos.3. El sistema actualiza la vista.|
@@ -250,39 +283,25 @@
 
 ---
 
-### ✅ CU-SALE-07 – Definir Estado de Venta
-
-| Ítem                       | Descripción                                                                                                   |
-| -------------------------- | ------------------------------------------------------------------------------------------------------------- |
-| 🆔 **Código**              | CU-SALE-07                                                                                                    |
-| 👤 **Actor**               | Dueño de Tienda                                                                                               |
-| 📋 **Descripción**         | Permite establecer el estado actual de la venta.                                                              |
-| 📌 **Precondición**        | La venta debe existir.                                                                                        |
-| 🎯 **Postcondición**       | Se actualiza su estado a: pendiente, confirmada, enviada, entregada, cancelada.                               |
-| 📑 **Flujo principal**     | 1. Selecciona una venta.2. Elige el nuevo estado desde un selector.3. El sistema guarda y actualiza la vista. |
-| ⚠️ **Flujos alternativos** | - 3a: Error al guardar → se muestra advertencia.                                                              |
-
----
-
-### ✅ CU-SALE-08 – Definir Método de Pago
+### ✅ CU-SALE-07 – Definir Método de Pago
 
 |Ítem|Descripción|
 |---|---|
-|🆔 **Código**|CU-SALE-08|
+|🆔 **Código**|CU-SALE-07|
 |👤 **Actor**|Dueño de Tienda|
 |📋 **Descripción**|Permite seleccionar el método de pago de una venta.|
 |📌 **Precondición**|Debe estar creando o editando una venta.|
-|🎯 **Postcondición**|El pago queda registrado como efectivo, tarjeta, transferencia, etc.|
+|🎯 **Postcondición**|El pago queda registrado como efectivo, transferencia o MercadoPago.|
 |📑 **Flujo principal**|1. En el formulario, selecciona método.2. El sistema guarda y lo asocia.|
 |⚠️ **Flujos alternativos**|- 2a: Método no válido → advertencia.|
 
 ---
 
-### ✅ CU-SALE-09 – Definir Método de Entrega
+### ✅ CU-SALE-08 – Definir Método de Entrega
 
 |Ítem|Descripción|
 |---|---|
-|🆔 **Código**|CU-SALE-09|
+|🆔 **Código**|CU-SALE-08|
 |👤 **Actor**|Dueño de Tienda|
 |📋 **Descripción**|Permite indicar si la venta es para envío o retiro.|
 |📌 **Precondición**|El formulario de venta debe estar activo.|
@@ -292,11 +311,11 @@
 
 ---
 
-### ✅ CU-SALE-10 – Ver Historial de Ventas
+### ✅ CU-SALE-09 – Ver Historial de Ventas
 
 | Ítem                       | Descripción                                                                                               |
 | -------------------------- | --------------------------------------------------------------------------------------------------------- |
-| 🆔 **Código**              | CU-SALE-10                                                                                                |
+| 🆔 **Código**              | CU-SALE-09                                                                                                |
 | 👤 **Actor**               | Dueño de Tienda                                                                                           |
 | 📋 **Descripción**         | Muestra todas las ventas pasadas en forma de historial.                                                   |
 | 📌 **Precondición**        | Deben existir ventas en la base.                                                                          |
@@ -352,27 +371,14 @@
 
 ---
 
-### ✅ CU-ORDER-04 – Confirmar o Cancelar Pedido
-
-|Ítem|Descripción|
-|---|---|
-|🆔 **Código**|CU-ORDER-04|
-|👤 **Actor**|Dueño de Tienda|
-|📋 **Descripción**|Permite gestionar pedidos recibidos, confirmándolos o cancelándolos.|
-|📌 **Precondición**|Debe haber pedidos pendientes en el sistema.|
-|🎯 **Postcondición**|El pedido cambia su estado a confirmado o cancelado.|
-|📑 **Flujo principal**|1. Accede a la lista de pedidos.2. Selecciona uno pendiente.3. Presiona “Confirmar” o “Cancelar”.4. El sistema actualiza el estado.5. Se notifica al cliente (vía WhatsApp o pantalla).|
-|⚠️ **Flujos alternativos**|- 3a: Ya fue confirmado/cancelado → advertencia.- 4a: Error al guardar cambios → mensaje.|
-
----
 ## 🎨 Módulo: Personalización de Tienda
 
 ---
-### ✅ CU‑STORE‑02 – Actualizar Información Básica
+### ✅ CU-STORE-01 – Actualizar Información Básica
 
 | Ítem                       | Descripción                                                                                                                                                                                                    |
 | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 🆔 **Código**              | CU‑STORE‑02                                                                                                                                                                                                    |
+| 🆔 **Código**              | CU-STORE-01                                                                                                                                                                                                    |
 | 👤 **Actor**               | Dueño de Tienda                                                                                                                                                                                                |
 | 📋 **Descripción**         | Editar nombre, descripción, slug, tipo y categoría de la tienda.                                                                                                                                               |
 | 📌 **Precondición**        | Debe existir un perfil de tienda y el usuario estar autenticado.                                                                                                                                               |
@@ -382,11 +388,11 @@
 
 ---
 
-### ✅ CU‑STORE‑03 – Actualizar Información de Contacto
+### ✅ CU-STORE-02 – Actualizar Información de Contacto
 
 |Ítem|Descripción|
 |---|---|
-|🆔 **Código**|CU‑STORE‑03|
+|🆔 **Código**|CU-STORE-02|
 |👤 **Actor**|Dueño de Tienda|
 |📋 **Descripción**|Modificar número de WhatsApp y sitio web de la tienda.|
 |📌 **Precondición**|Perfil existente; usuario autenticado.|
@@ -396,11 +402,11 @@
 
 ---
 
-### ✅ CU‑STORE‑04 – Actualizar Dirección Física
+### ✅ CU-STORE-03 – Actualizar Dirección Física
 
 |Ítem|Descripción|
 |---|---|
-|🆔 **Código**|CU‑STORE‑04|
+|🆔 **Código**|CU-STORE-03|
 |👤 **Actor**|Dueño de Tienda|
 |📋 **Descripción**|Actualizar calle, ciudad, provincia, país, zip code y enlace a Google Maps.|
 |📌 **Precondición**|Perfil existente; usuario autenticado.|
@@ -410,11 +416,11 @@
 
 ---
 
-### ✅ CU‑STORE‑05 – Configurar Horario Semanal
+### ✅ CU-STORE-04 – Configurar Horario Semanal
 
 |Ítem|Descripción|
 |---|---|
-|🆔 **Código**|CU‑STORE‑05|
+|🆔 **Código**|CU-STORE-04|
 |👤 **Actor**|Dueño de Tienda|
 |📋 **Descripción**|Definir apertura, cierre y descanso para cada día de la semana.|
 |📌 **Precondición**|Perfil existente; usuario autenticado.|
@@ -424,11 +430,11 @@
 
 ---
 
-### ✅ CU‑STORE‑06 – Actualizar Enlaces Sociales
+### ✅ CU-STORE-05 – Actualizar Enlaces Sociales
 
 |Ítem|Descripción|
 |---|---|
-|🆔 **Código**|CU‑STORE‑06|
+|🆔 **Código**|CU-STORE-05|
 |👤 **Actor**|Dueño de Tienda|
 |📋 **Descripción**|Agregar/editar URLs de Instagram y Facebook.|
 |📌 **Precondición**|Perfil existente; usuario autenticado.|
@@ -438,25 +444,25 @@
 
 ---
 
-### ✅ CU‑STORE‑07 – Configurar Tema / Branding
+### ✅ CU-STORE-06 – Configurar Tema / Branding
 
 |Ítem|Descripción|
 |---|---|
-|🆔 **Código**|CU‑STORE‑07|
+|🆔 **Código**|CU-STORE-06|
 |👤 **Actor**|Dueño de Tienda|
-|📋 **Descripción**|Personalizar logo, banner, colores y estilo visual de la tienda.|
+|📋 **Descripción**|Personalizar el aspecto de **la tienda pública del comercio** (logo, banner, colores y estilo visual). Nota: el diseño del panel/app es fijo; lo personalizable es la tienda.|
 |📌 **Precondición**|Perfil existente; usuario autenticado; Storage habilitado.|
 |🎯 **Postcondición**|`theme` actualizado con URLs e identificadores de color/fuente.|
 |📑 **Flujo principal**|1. “Perfil → Tema”.2. Subir `logo`/`banner` a Storage → obtener URL.3. Elegir `primaryColor`, `secondaryColor`, `accentColor`, `fontFamily`, `style`.4. Guardar y persistir.|
-|⚠️ **Flujos alternativos**|2a. Imagen supera límite de 1 MB → “Archivo muy grande”.|
+|⚠️ **Flujos alternativos**|2a. Imagen supera límite de 5 MB → “Archivo muy grande”.|
 
 ---
 
-### ✅ CU‑STORE‑08 – Configurar Métodos de Pago y Entrega
+### ✅ CU-STORE-07 – Configurar Métodos de Pago y Entrega
 
 |Ítem|Descripción|
 |---|---|
-|🆔 **Código**|CU‑STORE‑08|
+|🆔 **Código**|CU-STORE-07|
 |👤 **Actor**|Dueño de Tienda|
 |📋 **Descripción**|Habilitar y configurar métodos de pago (efectivo, transferencia, mercado pago) y entrega (retiro, delivery).|
 |📌 **Precondición**|Perfil existente; usuario autenticado.|
@@ -466,11 +472,11 @@
 
 ---
 
-### ✅ CU‑STORE‑09a – Configurar Notificaciones por WhatsApp
+### ✅ CU-STORE-08a – Configurar Notificaciones por WhatsApp
 
 |Ítem|Descripción|
 |---|---|
-|🆔 **Código**|CU‑STORE‑09a|
+|🆔 **Código**|CU-STORE-08a|
 |👤 **Actor**|Dueño de Tienda|
 |📋 **Descripción**|Activar/desactivar recepción de pedidos vía WhatsApp.|
 |📌 **Precondición**|Perfil existente; usuario autenticado.|
@@ -480,11 +486,11 @@
 
 ---
 
-### ✅ CU‑STORE‑09b – Configurar Notificaciones In‑App
+### ✅ CU-STORE-08b – Configurar Notificaciones In‑App
 
 |Ítem|Descripción|
 |---|---|
-|🆔 **Código**|CU‑STORE‑09b|
+|🆔 **Código**|CU-STORE-08b|
 |👤 **Actor**|Dueño de Tienda|
 |📋 **Descripción**|Activar/desactivar notificaciones dentro de la aplicación.|
 |📌 **Precondición**|Perfil existente; usuario autenticado.|
@@ -494,11 +500,11 @@
 
 ---
 
-### ✅ CU‑STORE‑09c – Configurar Push Notifications
+### ✅ CU-STORE-08c – Configurar Push Notifications
 
 | Ítem                       | Descripción                                                                         |
 | -------------------------- | ----------------------------------------------------------------------------------- |
-| 🆔 **Código**              | CU‑STORE‑09c                                                                        |
+| 🆔 **Código**              | CU-STORE-08c                                                                        |
 | 👤 **Actor**               | Dueño de Tienda                                                                     |
 | 📋 **Descripción**         | Activar/desactivar notificaciones push (web/mobile).                                |
 | 📌 **Precondición**        | Perfil existente; usuario autenticado; configuración FCM habilitada.                |
@@ -510,11 +516,11 @@
 ---
 
 
-### ✅ CU‑STORE‑10 – Gestionar Suscripción
+### ✅ CU-STORE-09 – Gestionar Suscripción
 
 |Ítem|Descripción|
 |---|---|
-|🆔 **Código**|CU‑STORE‑10|
+|🆔 **Código**|CU-STORE-09|
 |👤 **Actor**|Dueño de Tienda|
 |📋 **Descripción**|Ver y controlar estado de trial, plan activo, periodo de gracia y datos de facturación.|
 |📌 **Precondición**|Perfil existente; usuario autenticado.|
@@ -524,25 +530,25 @@
 
 ---
 
-### 💳 CU‑STORE‑11 – Activar y gestionar prueba gratuita (auto) + método de pago opcional
+### 💳 CU-STORE-10 – Activar y gestionar prueba gratuita (auto) + método de pago opcional
 
 | Ítem                       | Descripción                                                                                                                                                                                                                                                              |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| 🆔 **Código**              | CU‑STORE‑10                                                                                                                                                                                                                                                              |
+| 🆔 **Código**              | CU-STORE-10                                                                                                                                                                                                                                                              |
 | 👤 **Actor**               | Dueño de tienda                                                                                                                                                                                                                                                          |
 | 📋 **Descripción**         | Al crear una tienda, el sistema inicia automáticamente una prueba gratuita de 7 días. El dueño puede (opcionalmente) registrar un método de pago para renovaciones automáticas.                                                                                         |
-| 📌 **Precondición**        | El usuario creó la tienda (CU‑TIENDA‑06) y no tiene otra prueba usada en esa tienda (`trialUsed = false`).                                                                                                                                                               |
+| 📌 **Precondición**        | El usuario creó la tienda (ver onboarding) y no tiene otra prueba usada en esa tienda (`trialUsed = false`).                                                                                                                                                             |
 | 🎯 **Postcondición**       | Se setean:• `subscriptionActive = true`• `trialUsed = true`• `subscriptionStart = now()`• `subscriptionEnd = now() + 7 días`• (Opcional) `billing.provider = "MP"` y `billing.token` si cargó pago.                                                                     |
 | 📑 **Flujo principal**     | 1. Tras crear la tienda, el sistema crea automáticamente los campos de trial.2. Se muestra una pantalla “Bienvenido – Prueba activa hasta DD/MM/AAAA”.3. Botón **“Configurar método de pago”** (opcional).4. Si el usuario lo completa, se guardan los datos de billing. |
 | ⚠️ **Flujos alternativos** | 3‑a: Rechazo de token/MP → mostrar error y permitir reintentar más tarde.                                                                                                                                                                                                |
 
 ---
 
-### ⏳ CU‑STORE‑12 – Verificar suscripción y aplicar período de gracia
+### ⏳ CU-STORE-11 – Verificar suscripción y aplicar período de gracia
 
 | Ítem                       | Descripción                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 🆔 **Código**              | CU‑STORE‑11                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
+| 🆔 **Código**              | CU-STORE-11                                                                                                                                                                                                                                                                                                                                                                                                                                                 |
 | 👤 **Actor**               | Sistema (middleware)                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | 📋 **Descripción**         | En cada acceso a recursos de la tienda, el sistema evalúa el estado de suscripción: **activa**, **gracia (7 días)** o **suspendida**.                                                                                                                                                                                                                                                                                                                       |
 | 📌 **Precondición**        | La tienda tiene `subscriptionEnd` registrado.                                                                                                                                                                                                                                                                                                                                                                                                               |
@@ -552,11 +558,11 @@
 
 ---
 
-### 🔁 CU‑STORE‑13 – Renovar o pagar anticipadamente la suscripción
+### 🔁 CU-STORE-12 – Renovar o pagar anticipadamente la suscripción
 
 | Ítem                       | Descripción                                                                                                                                                                                                                                                                                   |
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 🆔 **Código**              | CU‑STORE‑12                                                                                                                                                                                                                                                                                   |
+| 🆔 **Código**              | CU-STORE-12                                                                                                                                                                                                                                                                                   |
 | 👤 **Actor**               | Dueño de tienda                                                                                                                                                                                                                                                                               |
 | 📋 **Descripción**         | El dueño puede pagar antes del vencimiento o durante el período de gracia para extender la suscripción (mensual/anual).                                                                                                                                                                       |
 | 📌 **Precondición**        | La tienda existe y el usuario es `owner`.                                                                                                                                                                                                                                                     |
@@ -566,11 +572,11 @@
 
 ---
 
-### 💳 CU‑STORE‑14 – Administrar método de pago (agregar / cambiar / quitar)
+### 💳 CU-STORE-13 – Administrar método de pago (agregar / cambiar / quitar)
 
 | Ítem                       | Descripción                                                                                                                                                                                               |
 | -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 🆔 **Código**              | CU‑STORE‑13                                                                                                                                                                                               |
+| 🆔 **Código**              | CU-STORE-13                                                                                                                                                                                               |
 | 👤 **Actor**               | Dueño de tienda                                                                                                                                                                                           |
 | 📋 **Descripción**         | Permite gestionar el método de pago usado para próximas renovaciones automáticas (Mercado Pago u otros).                                                                                                  |
 | 📌 **Precondición**        | La tienda existe; el usuario es `owner`.                                                                                                                                                                  |

--- a/docs/negocio/contexto-producto.md
+++ b/docs/negocio/contexto-producto.md
@@ -1,7 +1,7 @@
 # TuTiendaWeb — Documento Maestro de Contexto del Producto
 **Para qué sirve este archivo:** es el "cerebro" del negocio en un solo documento. Subilo a cualquier IA (ChatGPT, Claude, Gemini, generadores de imágenes, etc.) para que entienda exactamente qué es TuTiendaWeb, hasta dónde llega, cómo se usa y cómo explicarlo. Sirve para crear imágenes, mockups, campañas, guiones, textos y material de venta con contexto completo y fiel al producto real.
 
-**Última actualización:** 2026-06-12
+**Última actualización:** 2026-06-15
 **Idioma del producto y comunicación:** español argentino (voseo).
 
 ---
@@ -116,7 +116,8 @@ pedido llega ordenado al WhatsApp del DUEÑO → DUEÑO confirma y prepara
 - Cada producto: nombre, descripción, descripción corta, precio, **precio de costo** (para tu control interno de ganancia), categoría, etiquetas (tags), imágenes.
 - **Importación masiva desde Excel (.xlsx):** cargá hasta 300 productos de una sola vez con una planilla. El sistema crea automáticamente las categorías, subcategorías y tags que no existan. Incluye vista previa de filas válidas e inválidas antes de confirmar.
 - **Variantes / extras con precio** (ej: "extra queso +$1.000", "pan de la casa +$1.000"): el cliente los suma a su pedido y se calcula solo.
-- Organización por **categorías** (ej: Entradas, Principales, Postres) y **etiquetas**.
+- Organización por **categorías** y **subcategorías** (jerarquía de 2 niveles, ej: "Bebidas" → "Con alcohol" / "Sin alcohol") y por **etiquetas**.
+- **Orden personalizable de categorías y subcategorías:** el dueño define el orden en que aparecen en la tienda (arrastrando para reordenar).
 - Estado de producto (activo/inactivo) y soporte de promociones.
 - Listado filtrable y ordenable en el panel.
 
@@ -130,17 +131,17 @@ pedido llega ordenado al WhatsApp del DUEÑO → DUEÑO confirma y prepara
 ### 🛒 Pedidos por WhatsApp
 - El cliente arma el pedido y lo envía: llega **formateado y ordenado** al WhatsApp del negocio.
 - Generación de **ID automático** para cada pedido.
-- El dueño puede confirmar o cancelar pedidos.
+- El pedido entra y se **almacena como venta** (origen web/WhatsApp); la confirmación con el cliente se sigue haciendo por la conversación de WhatsApp.
 - El mensaje de WhatsApp se arma solo con el detalle del pedido, datos del cliente, método de pago y entrega.
 
 ### 🧾 Gestión de ventas (registro interno)
 - Crear ventas manualmente (además de las que entran por el catálogo).
 - Asociar productos, cantidades, datos del cliente, método de pago y entrega.
 - **Cálculo automático** de subtotal, descuentos y total.
-- **Estados de venta:** pendiente, confirmada, enviada, entregada, cancelada.
-- **Métodos de pago:** efectivo, tarjeta, transferencia, MercadoPago, etc.
+- La venta **no tiene flujo de estados**: se registra (se cierra) y se almacena. Cada venta guarda su **origen** (local, web o WhatsApp).
+- **Métodos de pago:** efectivo, transferencia, MercadoPago.
 - **Métodos de entrega:** retiro o delivery/envío.
-- Historial completo de ventas, filtrable por fecha, cliente, total y estado.
+- Historial completo de ventas, filtrable por fecha, cliente, total, método de pago, método de entrega y origen.
 - **Exportar ventas a PDF o Excel.**
 
 ### 📲 Código QR
@@ -210,7 +211,7 @@ Para mockups e imágenes del producto, estas son las secciones reales del panel 
 ### Para el DUEÑO (primera vez):
 1. **Registrate** con tu email o con Google.
 2. **Completá el onboarding:** nombre del negocio, tipo, WhatsApp, descripción, colores. Elegís la dirección web de tu tienda (slug).
-3. **Cargá tus productos:** foto, nombre, precio, descripción. Agrupalos en categorías. Si tenés muchos productos, usá la importación masiva por Excel para cargarlos todos de una vez.
+3. **Cargá tus productos:** foto, nombre, precio, descripción. Agrupalos en categorías y subcategorías, y ordenalas como querés que aparezcan en la tienda. Si tenés muchos productos, usá la importación masiva por Excel para cargarlos todos de una vez.
 4. **Agregá extras** si tu producto los tiene (ej: tamaños, agregados).
 5. **Personalizá tu tienda:** subí tu logo y elegí tus colores.
 6. **Configurá horarios, pagos y entrega.**
@@ -283,24 +284,28 @@ Para mockups e imágenes del producto, estas son las secciones reales del panel 
 
 ## 12. Guía para crear IMÁGENES y contenido visual
 
-### Estilo visual de marca ("Mercado Cálido")
-- **Sensación:** tienda viva, cálida, apetecible, confiable. NO frío/corporativo.
-- **Paleta:**
-  - Primario marca: Tomate/Coral `#E8552D`
-  - Acción (botones): Verde WhatsApp `#25D366`
-  - Acento: Mostaza/Miel `#F2A41C`
-  - Fondo: Crema `#FFF8F0`
-  - Texto: Carbón `#1A1714`
-- **Tipografía:** sans moderna con personalidad (Poppins, Sora) para títulos; legible (Inter, DM Sans) para cuerpo.
-- **Bordes redondeados, sombras suaves cálidas.**
+> ⚠️ Distinción clave: **el diseño de la APP (panel del dueño) es fijo** y lo define el sistema de diseño de TuTiendaWeb. **La TIENDA pública NO tiene diseño fijo:** cada comercio configura su propia marca (logo, color principal, portada, textos). Los colores de abajo son los de la **app y la marca TuTiendaWeb**, no los de la tienda de cada comercio.
+
+### Sistema de diseño de la marca / app (fijo)
+- **Sin gradientes en ningún lado:** todo es **tinta plana** (botones, logo, superficies).
+- **Color de marca / primario:** violeta **`#7C3AED`**.
+- **Azul `#2563eb`:** precios y links dentro del panel.
+- **Verde WhatsApp `#25D366`:** reservado **solo para la acción** (el botón "tap me" de pedir/enviar). No usarlo como color decorativo.
+- **Neutros:** escala **slate** (grises fríos) para el chrome del panel.
+- **Tipografía:** **Plus Jakarta Sans** (Poppins disponible solo como display opcional para piezas de marketing).
+- **Bordes redondeados generosos** y **sombras suaves**.
 - **Fotos reales** de comida/productos/comercios argentinos. Nada de stock genérico de oficinas.
-- **El verde solo para los botones de acción** (que el ojo sepa dónde tocar).
+
+### El logo
+- Glifo de **teléfono delineado detrás de una bolsa sólida**, plano y minimal, con un corte limpio donde se encuentran. **Sin gradientes.**
+- Una sola tinta: **violeta `#7C3AED`**, negro o blanco (según el fondo).
+- Wordmark: **Tu**`Tienda`**Web**, con "Tienda" en violeta.
 
 ### Qué mostrar en las imágenes (ideas fieles al producto):
 - Un **celular con el catálogo abierto** (productos con fotos y precios).
 - El **mensaje de WhatsApp** llegando con un pedido armado.
 - Un **QR impreso** en una mesa o mostrador, alguien escaneándolo.
-- El **panel del dueño** (productos, ventas, reportes).
+- El **panel del dueño** (productos con categorías/subcategorías, ventas, reportes).
 - **Antes/después:** papelitos desordenados → pedido ordenado en el WhatsApp.
 - Comparación visual: **comisión de delivery (-30%) vs. precio fijo ($15.000)**.
 - El **dueño real** de un comercio sonriendo, preparando un pedido.
@@ -334,7 +339,8 @@ Para mockups e imágenes del producto, estas son las secciones reales del panel 
 - **Dashboard / Panel:** la zona privada donde el dueño gestiona todo.
 - **Onboarding:** el asistente inicial que configura la tienda paso a paso.
 - **Variantes / Extras:** opciones con precio que se suman a un producto (tamaños, agregados).
-- **Estados de venta:** pendiente, confirmada, enviada, entregada, cancelada.
+- **Subcategoría:** segundo nivel dentro de una categoría (ej: "Bebidas" → "Sin alcohol").
+- **Origen de venta:** de dónde provino la venta (local, web o WhatsApp). La venta no tiene estados; se registra y se almacena.
 - **Período de gracia:** tiempo extra tras vencer la suscripción antes de suspender la cuenta.
 - **Owner (dueño):** rol con acceso completo a su tienda.
 

--- a/docs/negocio/requerimientos.md
+++ b/docs/negocio/requerimientos.md
@@ -2,6 +2,8 @@
 
 Este documento describe los requerimientos funcionales y no funcionales del sistema **TuTiendaWeb**, en el contexto del desarrollo como solución integral para la gestión de tiendas físicas y virtuales.
 
+> **Actualizado:** 2026-06-15. Numeración correlativa: `RF##` (funcionales), `RF-STORE-##` (configuración de la tienda) y `RNF##` (no funcionales).
+
 ---
 
 ## 🧩 1. Requerimientos Funcionales (RF)
@@ -12,100 +14,92 @@ Los requerimientos funcionales definen lo que el sistema **debe hacer** desde la
 
 ### 🛍️ Gestión de Productos
 
-| Código | Requerimiento                                                                                   |
-| ------ | ----------------------------------------------------------------------------------------------- |
-| RF01   | El sistema debe permitir al dueño de la tienda registrar un nuevo producto.                     |
-| RF02   | El sistema debe permitir editar los datos de un producto existente.                             |
-| RF03   | El sistema debe permitir eliminar un producto.                                                  |
-| RF04   | El sistema debe listar todos los productos disponibles en una tabla filtrable y ordenable.      |
-| RF05   | El sistema debe permitir visualizar el catálogo de productos públicamente (modo tienda online). |
-| RF32   | El sistema debe permitir importar productos de forma masiva desde un archivo Excel (.xlsx), con un límite de 300 productos por tienda. El sistema debe validar cada fila, crear automáticamente las categorías/subcategorías/tags inexistentes, informar las filas inválidas antes de confirmar, y aplicar el límite tanto por archivo como por total de productos en la tienda. |
+| Código | Requerimiento |
+| ------ | ------------- |
+| RF01 | El sistema debe permitir al dueño de la tienda registrar un nuevo producto. |
+| RF02 | El sistema debe permitir editar los datos de un producto existente. |
+| RF03 | El sistema debe permitir eliminar un producto. |
+| RF04 | El sistema debe listar todos los productos disponibles en una tabla filtrable y ordenable. |
+| RF05 | El sistema debe permitir visualizar el catálogo de productos públicamente (modo tienda online). |
+| RF06 | El sistema debe permitir añadir opciones/extras con valor opcional a un producto (ej: "extra queso +$1.000"), que se suman al precio del pedido. |
+| RF07 | El sistema debe permitir organizar los productos en categorías y subcategorías (jerarquía de 2 niveles: categoría principal → subcategoría). |
+| RF08 | El sistema debe permitir al dueño definir manualmente el orden de las categorías y subcategorías, que determina cómo aparecen en la tienda pública. |
+| RF09 | El sistema debe permitir importar productos de forma masiva desde un archivo Excel (.xlsx), con un límite de 300 productos por tienda. Debe validar cada fila, crear automáticamente las categorías/subcategorías/tags inexistentes, informar las filas inválidas antes de confirmar, y aplicar el límite tanto por archivo como por total de productos en la tienda. |
 
 ---
 
 ### 🧾 Gestión de Ventas
 
-| Código | Requerimiento                                                                                                 |
-| ------ | ------------------------------------------------------------------------------------------------------------- |
-| RF06   | El sistema debe permitir crear una venta, asociando uno o más productos, cantidades, método de pago y estado. |
-| RF07   | El sistema debe permitir editar ventas existentes.                                                            |
-| RF08   | El sistema debe calcular automáticamente subtotal, descuentos, impuestos(si aplica) y total final.            |
-| RF09   | El sistema debe permitir exportar ventas en formato PDF y/o Excel.                                            |
-| RF10   | El sistema debe permitir visualizar y filtrar ventas por fecha, cliente, estado o total.                      |
-| RF11   | El sistema debe permitir registrar información del cliente (nombre, teléfono, dirección, notas).              |
-| RF12   | El sistema debe permitir definir estados de venta: pendiente, confirmada, enviada, entregada, cancelada.      |
-| RF13   | El sistema debe permitir seleccionar métodos de pago: efectivo, transferencia, tarjeta, etc.                  |
-| RF14   | El sistema debe permitir seleccionar métodos de entrega: retiro, envió.                                       |
-| RF15   | El sistema debe mostrar historial de ventas.                                                                  |
+| Código | Requerimiento |
+| ------ | ------------- |
+| RF10 | El sistema debe permitir crear una venta asociando uno o más productos, cantidades, cliente, método de pago y entrega. La venta se cierra y se almacena (no tiene flujo de estados); registra su origen: local, web o WhatsApp. |
+| RF11 | El sistema debe permitir editar ventas existentes. |
+| RF12 | El sistema debe calcular automáticamente subtotal, descuentos y total final. |
+| RF13 | El sistema debe permitir exportar ventas en formato PDF y/o Excel. |
+| RF14 | El sistema debe permitir visualizar y filtrar ventas por fecha, cliente, total, método de pago, método de entrega y origen. |
+| RF15 | El sistema debe permitir registrar información del cliente (nombre, teléfono, dirección, notas). |
+| RF16 | El sistema debe permitir seleccionar el método de pago: efectivo, transferencia o MercadoPago. |
+| RF17 | El sistema debe permitir seleccionar el método de entrega: retiro o delivery/envío. |
+| RF18 | El sistema debe mostrar el historial de ventas. |
 
 ---
 
 ### 🛒 Pedidos y Tienda Online
 
-| Código | Requerimiento                                                                                                              |
-| ------ | -------------------------------------------------------------------------------------------------------------------------- |
-| RF16   | El sistema debe generar un link de la Tienda para ser compartido vía WhatsApp u otro canal.                                |
-| RF17   | El cliente debe poder seleccionar productos y completar sus datos personales desde el catálogo público y enviar su pedido. |
-| RF18   | El sistema debe generar automáticamente un ID de pedido.                                                                   |
-| RF19   | El dueño de tienda debe poder confirmar o cancelar pedidos entrantes(mediante whatsapp y  desde la app).                   |
-| RF20   | El sistema debe permitir al dueño de la tienda personalizar los datos de la tienda, imágenes, y próximamente colores.      |
+| Código | Requerimiento |
+| ------ | ------------- |
+| RF19 | El sistema debe generar un link único de la tienda para compartir el catálogo vía WhatsApp u otro canal, y un código QR exportable. |
+| RF20 | El cliente debe poder seleccionar productos, agregar extras y completar sus datos desde el catálogo público para enviar su pedido. |
+| RF21 | El sistema debe generar automáticamente un ID para cada pedido. |
+| RF22 | El sistema debe recibir y almacenar el pedido entrante como una venta (origen web/WhatsApp); la confirmación con el cliente se realiza por la conversación de WhatsApp. |
+| RF23 | El sistema debe permitir al dueño personalizar los datos, imágenes y colores de su tienda pública. |
 
-## Tienda Online
-## 🧩 Requerimientos Funcionales (RF)
+---
 
-1. **RF‑STORE‑2 – Actualizar Información Básica**
-    
-2. **RF‑STORE‑3 – Actualizar Información de Contacto**
-    
-3. **RF‑STORE‑4 – Actualizar Dirección Física**
-    
-4. **RF‑STORE‑5 – Configurar Horario Semanal**
-    
-5. **RF‑STORE‑6 – Actualizar Enlaces Sociales**
-    
-6. **RF‑STORE‑7 – Configurar Tema / Branding**
-    
-7. **RF‑STORE‑8 – Configurar Métodos de Pago y Entrega**
-    
-8. **RF‑STORE‑9 – Configurar Notificaciones**
-    
-    - 9a. Por WhatsApp
-        
-    - 9b. In‑App
-        
-    - 9c. Push
-        
-    - 9d. Prueba de notificaciones
-        
-9. **RF‑STORE‑10 – Gestionar Suscripción**
+### ⚙️ Configuración de la Tienda
+
+> El diseño del **panel/app es fijo**; lo configurable por cada comercio es **su tienda pública** y los ajustes operativos.
+
+| Código | Requerimiento |
+| ------ | ------------- |
+| RF-STORE-01 | Actualizar información básica (nombre, descripción, slug, tipo y categoría). |
+| RF-STORE-02 | Actualizar información de contacto (WhatsApp, sitio web). |
+| RF-STORE-03 | Actualizar dirección física y enlace a Google Maps. |
+| RF-STORE-04 | Configurar el horario semanal (apertura, cierre y descanso por día). |
+| RF-STORE-05 | Actualizar enlaces a redes sociales (Instagram, Facebook). |
+| RF-STORE-06 | Configurar el tema/branding de la tienda pública (logo, banner, colores, estilo). |
+| RF-STORE-07 | Configurar métodos de pago y de entrega (con instrucciones y precio de envío). |
+| RF-STORE-08 | Configurar notificaciones: WhatsApp, in-app, push y prueba de notificaciones. |
+| RF-STORE-09 | Gestionar la suscripción (trial, plan activo, período de gracia y facturación). |
+| RF-STORE-10 | Calcular dinámicamente el estado abierto/cerrado de la tienda según el horario. |
+
+---
+
 ### 👥 Gestión de Usuarios y Autenticación
 
-| Código | Requerimiento                                                                                      |
-| ------ | -------------------------------------------------------------------------------------------------- |
-| RF21   | El sistema debe permitir iniciar sesión email y contraseña o por cuenta de google.                 |
-| RF22   | El sistema debe restringir el acceso a funcionalidades según autenticación (como la de dashboard). |
-| RF23   | El sistema debe permitir al usuario nuevo registrarse.                                             |
-|        |                                                                                                    |
+| Código | Requerimiento |
+| ------ | ------------- |
+| RF24 | El sistema debe permitir iniciar sesión con email y contraseña o con cuenta de Google. |
+| RF25 | El sistema debe restringir el acceso a las funcionalidades según autenticación (p. ej. el dashboard). |
+| RF26 | El sistema debe permitir que un usuario nuevo se registre. |
 
 ---
 
 ### 📊 Reportes y Exportaciones
 
-| Código | Requerimiento                                                                                                     |
-| ------ | ----------------------------------------------------------------------------------------------------------------- |
-| RF24   | El sistema debe generar reportes de ventas por rango de fechas.                                                   |
-| RF25   | El sistema debe permitir exportar reportes en Excel.                                                              |
-| RF26   | El sistema debe mostrar métricas simples: ventas totales, ganancias, promedio por ticket, hora de mas movimiento. |
+| Código | Requerimiento |
+| ------ | ------------- |
+| RF27 | El sistema debe generar reportes de ventas por rango de fechas. |
+| RF28 | El sistema debe permitir exportar reportes en Excel. |
+| RF29 | El sistema debe mostrar métricas: ventas totales, ganancias, ticket promedio y mejores días/horarios. |
 
-###  Requerimientos Funcionales – Nuevos o Modificados
+---
 
-|Código|Requerimiento|
-|---|---|
-|RF27|El sistema debe permitir configurar múltiples tiendas por usuario.|
-|RF28|El sistema debe permitir configurar los métodos de entrega, pago y canal de recepción del pedido.|
-|RF29|El sistema debe permitir asociar disponibilidad horaria y días por producto.|
-|RF30|El sistema debe permitir añadir opciones personalizadas (extras) a los productos con valor opcional.|
-|RF31|El sistema debe permitir calcular dinámicamente el estado abierto/cerrado de la tienda.|
+### 🔭 Visión a futuro
+
+| Código | Requerimiento |
+| ------ | ------------- |
+| RF30 | El sistema debería permitir gestionar múltiples tiendas bajo una misma cuenta (multitienda). |
 
 ---
 
@@ -117,18 +111,18 @@ Los requerimientos no funcionales definen cómo debe comportarse el sistema en t
 
 ### 🔐 Seguridad
 
-| Código | Requerimiento                                                                             |
-| ------ | ----------------------------------------------------------------------------------------- |
-| RNF01  | El sistema debe proteger las rutas y componentes sensibles mediante autenticación.        |
-| RNF02  | El sistema debe almacenar los datos de usuario y venta de forma segura (usando Firebase). |
-| RNF03  | El sistema debe restringir acciones críticas a usuarios autenticados.                     |
+| Código | Requerimiento |
+| ------ | ------------- |
+| RNF01 | El sistema debe proteger las rutas y componentes sensibles mediante autenticación. |
+| RNF02 | El sistema debe almacenar los datos de usuario y venta de forma segura (usando Firebase). |
+| RNF03 | El sistema debe restringir las acciones críticas a usuarios autenticados. |
 
 ---
 
 ### 📈 Rendimiento y Escalabilidad
 
 | Código | Requerimiento |
-|--------|----------------|
+| ------ | ------------- |
 | RNF04 | El sistema debe estar optimizado para funcionar en dispositivos móviles y de escritorio. |
 | RNF05 | El sistema debe poder escalar horizontalmente sin rediseño, gracias al uso de Firebase. |
 
@@ -136,35 +130,32 @@ Los requerimientos no funcionales definen cómo debe comportarse el sistema en t
 
 ### 🌐 Disponibilidad y Hosting
 
-| Código | Requerimiento                                                                  |
-| ------ | ------------------------------------------------------------------------------ |
-| RNF06  | El sistema debe estar disponible 24/7, alojado en Firebase Hosting o Vercel.   |
-| RNF07  | Las operaciones de lectura y escritura deben responder en menos de 2 segundos. |
+| Código | Requerimiento |
+| ------ | ------------- |
+| RNF06 | El sistema debe estar disponible 24/7, alojado en Vercel (y/o Firebase Hosting). |
+| RNF07 | Las operaciones de lectura y escritura deben responder en menos de 2 segundos. |
 
 ---
 
 ### 🛠️ Mantenibilidad
 
 | Código | Requerimiento |
-|--------|----------------|
-| RNF08 | El sistema debe estar modularizado por feature para facilitar mantenimiento. |
+| ------ | ------------- |
+| RNF08 | El sistema debe estar modularizado por feature para facilitar el mantenimiento. |
 | RNF09 | El sistema debe estar documentado con comentarios, tipos TypeScript y validaciones Zod. |
-| RNF10 | El sistema debe permitir despliegue automático en producción mediante Vercel o Firebase CI/CD. |
+| RNF10 | El sistema debe permitir despliegue automático en producción mediante CI/CD (Vercel). |
 
 ---
 
 ### 🌍 Internacionalización (Opcional / Futuro)
 
 | Código | Requerimiento |
-|--------|----------------|
+| ------ | ------------- |
 | RNF11 | El sistema debería permitir soporte multilenguaje (español / inglés). |
 
 ---
 
-
-
 ## 🔚 Notas Finales
 
-- Cada RF y RNF podrá estar vinculado a uno o varios Casos de Uso, Diagramas y Features en la documentación técnica.
+- Cada RF y RNF podrá estar vinculado a uno o varios Casos de Uso, diagramas y features en la documentación técnica.
 - Esta lista puede ampliarse a medida que el sistema evolucione.
-


### PR DESCRIPTION
- Documentar subcategorias (jerarquia 2 niveles) y orden manual de categorias; consolidar import de productos por Excel.

- Reemplazar el sistema de estilos: app con diseno fijo (violeta #7C3AED, azul precios/links, verde WhatsApp solo accion, slate, Plus Jakarta Sans) vs. tienda publica personalizable por cada comercio. Nuevo logo (telefono+bolsa, plano). Quitar paleta Mercado Calido y fuentes viejas.

- Reflejar que la venta no tiene estados: se cierra y se almacena (origen local/web/WhatsApp). Quitar confirmar/cancelar pedidos y los 5 estados.

- Quitar requerimiento inexistente (disponibilidad horaria por producto) y referencias a stock; alinear limite de imagen a 5 MB.

- Renumerar de forma correlativa RF/RF-STORE/CU y agregar encabezados/fechas.

## Qué cambia
-

## Por qué
-

## Cómo probar
- Pasos, datos de prueba, capturas.

## Checklist
- [ ] Lint/Tipos/Tests OK
- [ ] No incluye secretos ni credenciales
- [ ] Docs/README actualizados si aplica
