### PR TITLE
test(integration): Fase 2 · PR6 — Auth, claims y cierre de Fase 2

### DIFF
--- a/docs/test/README.md
+++ b/docs/test/README.md
@@ -72,7 +72,14 @@ npm run test:e2e:ui   # E2E modo interactivo
   - **Funciones puras:** `format.utils`, `firestore-serializer`, `cleanForFirestore`, `sell.utils`, `product.utils`, `whatsapp.utils`. *(helpers privados de `category.service` quedan para Fase 2: el módulo importa `firebase-admin`.)*
   - **Componentes (Testing Library):** `LoginForm`, `CheckoutForm` (incluye chequeo H-1: el checkout envía items sin precios), `ProductForm`. Se agregó polyfill global de `ResizeObserver`/`matchMedia` en `vitest.setup.ts`.
   - **Diferido a E2E (Fase 4):** `MultiStepRegister` y `OnboardingWizard` (wizards multi-paso, mejor cubiertos end-to-end). Los gates de cobertura `store/services/**` y `sells/**` se cumplen en Fase 2 (integración) y el gate global (≥80%) en Fase 5.
-- **Fase 2** — Integración con emuladores: checkout (H-1), sells, products, import, auth.
+- **Fase 2** — Integración con emuladores. ✅ **93 tests verdes** (`npm run test:int`, 6 suites).
+  - **Checkout / H-1:** `buildTrustedSale` y `processCheckoutAction` con test de price-tampering y de costo de envío recalculado server-side.
+  - **Sells:** CRUD + recálculo de totales (dot-notation), filtros de `getSales`, `calculateSalesStats`, venta pública sin sesión.
+  - **Products + import:** CRUD de service, `isValidSubcategory`, toggle/delete con limpieza real en Storage emulado, `bulkCreateProducts` (dedupe, topes 50/30, batches de 450) e `importProductsAction` (warnings + tope).
+  - **Categories / Tags:** jerarquía de 2 niveles, orden, unicidad, borrado bloqueado por uso (`CATEGORY_NOT_EMPTY`), `getTags`.
+  - **Store settings:** lectura serializada, updates por sección, slug único case-insensitive (merge sin pisar otras secciones).
+  - **Auth / claims:** custom claims reales (Auth emulado), `getServerSession` con ID token minteado vía REST (claims + fallback `storeId`), `user.service`, `registerAction`, `checkSlugAvailabilityAction`.
+  - Infra añadida: `test/helpers/integration-mocks.ts` (shim de `react.cache` y `next/cache`) y job `emulators` en `ci.yml`. Suites idempotentes: 3 corridas seguidas en verde.
 - **Fase 3** — Auditoría de reglas Firestore/Storage.
 - **Fase 4** — E2E de los 6 flujos críticos.
 - **Fase 5** — Gates de cobertura en CI y cierre de documentación.

--- a/test/integration/auth.int.test.ts
+++ b/test/integration/auth.int.test.ts
@@ -1,0 +1,229 @@
+/**
+ * Tests de integración de autenticación y custom claims (Fase 2).
+ *
+ * A diferencia de las otras suites, aquí NO se mockea la sesión: se ejercita el
+ * flujo real de claims contra el emulador de Auth (`adminAuth`), el armado de
+ * `getServerSession` a partir de un ID token real (minteado vía REST del
+ * emulador) y los servicios de usuario en Firestore.
+ *
+ * Guía: docs/test/20-integration-guide.md (sección 6 · Auth / claims).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Estado de cookie mutable compartido con el mock de next/headers.
+const cookieState = vi.hoisted(() => ({ value: undefined as string | undefined }));
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(async () => ({
+    get: (name: string) =>
+      name === 'session' && cookieState.value ? { value: cookieState.value } : undefined,
+    set: vi.fn(),
+    delete: vi.fn(),
+  })),
+}));
+
+import {
+  setUserClaims,
+  getUserClaims,
+  updateUserClaims,
+  revokeUserTokens,
+} from '@/features/auth/services/server/auth.service';
+import { getServerSession } from '@/lib/auth/server-session';
+import {
+  createUserInFirestore,
+  getUserFromFirestore,
+  getOrCreateUserFromGoogle,
+} from '@/features/user/services/user.service';
+import { registerAction, checkSlugAvailabilityAction } from '@/features/auth/actions/auth.actions';
+import { adminDb, adminAuth, clearFirestore, clearAuth } from '../helpers/firebase-emulator';
+import { makeStore } from '../helpers/factories';
+
+const AUTH_HOST = process.env.FIREBASE_AUTH_EMULATOR_HOST ?? '127.0.0.1:9099';
+const API_KEY = 'fake-api-key';
+
+/** Crea un usuario en el emulador de Auth vía REST y devuelve sus tokens. */
+async function signUp(email: string, password = 'Password1') {
+  const res = await fetch(
+    `http://${AUTH_HOST}/identitytoolkit.googleapis.com/v1/accounts:signUp?key=${API_KEY}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password, returnSecureToken: true }),
+    },
+  );
+  return (await res.json()) as { localId: string; idToken: string; refreshToken: string };
+}
+
+/** Refresca un ID token (recoge claims actualizados después de setUserClaims). */
+async function refreshIdToken(refreshToken: string): Promise<string> {
+  const res = await fetch(`http://${AUTH_HOST}/securetoken.googleapis.com/v1/token?key=${API_KEY}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ grant_type: 'refresh_token', refresh_token: refreshToken }),
+  });
+  return ((await res.json()) as { id_token: string }).id_token;
+}
+
+beforeEach(async () => {
+  await clearFirestore();
+  await clearAuth();
+  cookieState.value = undefined;
+});
+
+describe('Custom claims (Auth emulado)', () => {
+  it('setea y lee claims', async () => {
+    const user = await adminAuth().createUser({ email: 'claims@test.com' });
+    await setUserClaims(user.uid, { storeId: 's1', role: 'owner' });
+
+    expect(await getUserClaims(user.uid)).toEqual({ storeId: 's1', role: 'owner' });
+  });
+
+  it('actualiza claims haciendo merge con los existentes', async () => {
+    const user = await adminAuth().createUser({ email: 'claims2@test.com' });
+    await setUserClaims(user.uid, { storeId: 's1', role: 'owner' });
+
+    await updateUserClaims(user.uid, { role: 'admin' });
+
+    expect(await getUserClaims(user.uid)).toEqual({ storeId: 's1', role: 'admin' });
+  });
+
+  it('revoca tokens sin lanzar', async () => {
+    const user = await adminAuth().createUser({ email: 'claims3@test.com' });
+    await expect(revokeUserTokens(user.uid)).resolves.toBeUndefined();
+  });
+});
+
+describe('getServerSession', () => {
+  it('arma la sesión con storeId/role desde los claims del token', async () => {
+    const { localId, refreshToken } = await signUp('session@test.com');
+    await setUserClaims(localId, { storeId: 'store-x', role: 'owner' });
+    cookieState.value = await refreshIdToken(refreshToken);
+
+    const session = await getServerSession();
+    expect(session?.userId).toBe(localId);
+    expect(session?.storeId).toBe('store-x');
+    expect(session?.role).toBe('owner');
+  });
+
+  it('hace fallback a Firestore cuando el token no tiene storeId en claims', async () => {
+    const { localId, idToken } = await signUp('fallback@test.com');
+    await adminDb()
+      .collection('stores')
+      .doc('store-fallback')
+      .set(makeStore({ metadata: { ownerId: localId } }));
+    cookieState.value = idToken;
+
+    const session = await getServerSession();
+    expect(session?.storeId).toBe('store-fallback');
+    expect(session?.role).toBeNull();
+  });
+
+  it('devuelve null sin cookie de sesión', async () => {
+    expect(await getServerSession()).toBeNull();
+  });
+
+  it('devuelve null con un token inválido', async () => {
+    cookieState.value = 'token-invalido';
+    expect(await getServerSession()).toBeNull();
+  });
+});
+
+describe('user.service', () => {
+  it('crea y lee un usuario en Firestore', async () => {
+    await createUserInFirestore('u-fs', {
+      email: 'fs@test.com',
+      displayName: 'Usuario FS',
+      role: 'user',
+    });
+
+    const user = await getUserFromFirestore('u-fs');
+    expect(user?.email).toBe('fs@test.com');
+    expect(user?.displayName).toBe('Usuario FS');
+  });
+
+  it('getUserFromFirestore devuelve null si no existe', async () => {
+    expect(await getUserFromFirestore('no-existe')).toBeNull();
+  });
+
+  it('getOrCreateUserFromGoogle crea una vez y es idempotente', async () => {
+    const decoded = {
+      uid: 'g1',
+      email: 'g@test.com',
+      name: 'Goo Gle',
+      picture: 'https://x/p.png',
+    } as never;
+
+    await getOrCreateUserFromGoogle(decoded);
+    await getOrCreateUserFromGoogle(decoded); // segunda vez: no duplica
+
+    const all = await adminDb().collection('users').get();
+    expect(all.size).toBe(1);
+    expect(all.docs[0].id).toBe('g1');
+  });
+});
+
+describe('registerAction', () => {
+  it('registra un usuario nuevo en Auth y Firestore', async () => {
+    const fd = new FormData();
+    fd.set('email', 'nuevo@test.com');
+    fd.set('password', 'Password1');
+    fd.set('displayName', 'Nuevo Usuario');
+
+    const res = await registerAction(null, fd);
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+
+    const user = await getUserFromFirestore(res.data.userId);
+    expect(user?.email).toBe('nuevo@test.com');
+  });
+
+  it('rechaza un email ya registrado', async () => {
+    await adminAuth().createUser({ email: 'dup@test.com', password: 'Password1' });
+
+    const fd = new FormData();
+    fd.set('email', 'dup@test.com');
+    fd.set('password', 'Password1');
+    fd.set('displayName', 'Duplicado');
+
+    const res = await registerAction(null, fd);
+    expect(res.success).toBe(false);
+    if (res.success) return;
+    expect(res.errors.email).toBeDefined();
+  });
+
+  it('rechaza una contraseña débil (sin mayúscula ni número)', async () => {
+    const fd = new FormData();
+    fd.set('email', 'weak@test.com');
+    fd.set('password', 'password');
+    fd.set('displayName', 'Débil');
+
+    const res = await registerAction(null, fd);
+    expect(res.success).toBe(false);
+  });
+});
+
+describe('checkSlugAvailabilityAction', () => {
+  it('devuelve disponible para un slug libre', async () => {
+    const res = await checkSlugAvailabilityAction('slug-libre');
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    expect(res.data.isAvailable).toBe(true);
+  });
+
+  it('devuelve no disponible para un slug ya tomado', async () => {
+    await adminDb()
+      .collection('stores')
+      .doc('store-slug')
+      .set(makeStore({ basicInfo: { name: 'X', slug: 'tomado', description: 'x', type: 'retail' } }));
+
+    const res = await checkSlugAvailabilityAction('tomado');
+    expect(res.success).toBe(true);
+    if (!res.success) return;
+    expect(res.data.isAvailable).toBe(false);
+  });
+
+  it('rechaza un slug con formato inválido', async () => {
+    const res = await checkSlugAvailabilityAction('AB'); // mayúsculas y muy corto
+    expect(res.success).toBe(false);
+  });
+});


### PR DESCRIPTION
## Fase 2 — Integración con emuladores · PR 6 de 6 (apilado sobre #57)

> ⚠️ **Base: `test/fase2-store-settings` (PR #57)**. Último de la pila; mergear #53–#57 primero.

### Qué incluye
- **`test/integration/auth.int.test.ts`** (16 tests): custom claims reales contra Auth emulado (`setUserClaims`/`getUserClaims`/`updateUserClaims`/`revokeUserTokens`), `getServerSession` armado desde un **ID token real minteado vía REST del emulador** (claims presentes + fallback de `storeId` por Firestore + tokens inválidos), `user.service` (`createUserInFirestore`/`getUserFromFirestore`/`getOrCreateUserFromGoogle` idempotente), `registerAction` (alta + email duplicado + password débil) y `checkSlugAvailabilityAction`.
- **`docs/test/README.md`**: roadmap de Fase 2 marcado como **✅ completado** (93 tests, 6 suites).

### Verificación
16/16 verdes · suite completa **93/93** corrida 3 veces seguidas en un mismo emulador (aislamiento e idempotencia OK) · typecheck/lint limpios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)