### PR TITLE
test(rules): Fase 3 · auditoría de reglas Firestore/Storage + fix SEC-01

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,6 @@ jobs:
           distribution: temurin
           java-version: 21
       - run: npm install --ignore-scripts
-      # Solo los emuladores que usan los tests de integración (sin functions).
-      - run: npx -y firebase-tools@latest emulators:exec --project demo-tutiendaweb --only auth,firestore,storage "npm run test:int"
+      # Solo los emuladores que usan los tests de integración + reglas (sin functions).
+      # Un único emulators:exec corre integración (Fase 2) y reglas (Fase 3).
+      - run: npx -y firebase-tools@latest emulators:exec --project demo-tutiendaweb --only auth,firestore,storage "npm run test:int && npm run test:rules"

--- a/docs/hallazgos/hallazgos-por-usuarios.md
+++ b/docs/hallazgos/hallazgos-por-usuarios.md
@@ -1,0 +1,4 @@
+algunos links como configuracion mandan a 404, revisar bien eso, 
+
+mejorar la estructura de las condiguraciones, horarios debe tener su propio lugar. 
+

--- a/docs/hallazgos/testing-fase3-2026-06-19.md
+++ b/docs/hallazgos/testing-fase3-2026-06-19.md
@@ -1,0 +1,137 @@
+# Hallazgos — Fase 3 de testing (auditoría de reglas) (2026-06-19)
+
+Detectados al escribir la suite de reglas (`test/rules/*.rules.test.ts`, 81 casos)
+y al auditar `firestore.rules`/`storage.rules` con la skill
+`firebase-security-rules-auditor`.
+
+Política aplicada (instrucción del usuario): los hallazgos de seguridad
+**crítico/alto** se corrigen en este PR (documentados como "hallazgo corregido");
+los medios/bajos se documentan sin tocar las reglas.
+
+> Tabla resumen y matriz allow/deny completa en
+> [docs/test/60-firebase-security-audit.md](../test/60-firebase-security-audit.md).
+
+---
+
+## SEC-01 (Alta) — ✅ RESUELTO — `sells.create` público sin topes de tamaño
+
+**Archivo:** `firestore.rules` (`isValidSellData()`)
+
+**Problema:**
+- `sells.create` es la **única escritura pública (sin autenticación)** del modelo
+  (el checkout del catálogo crea ventas anónimas).
+- `isValidSellData()` validaba las keys requeridas, que `storeId` coincidiera con el
+  path, `totals.total >= 0` y `customer.name` no vacío, pero **no acotaba tamaños**:
+  - `items` podía ser un array arbitrariamente grande.
+  - `customer.name` podía ser un string ilimitado.
+- Un atacante anónimo que escriba directo a Firestore (salteándose la app) podía
+  crear documentos de venta **gigantes o masivos** en `stores/{id}/sells` →
+  *resource exhaustion* / costos de almacenamiento y **contaminación del dashboard**
+  del comercio (KPIs, listados).
+
+**Por qué es seguro corregirlo:** la ruta legítima de checkout crea ventas desde el
+Server Action `createPublicSaleAction` usando el **Admin SDK**, que **bypasea las
+reglas**. No existe un flujo legítimo que escriba `sells` directamente desde el
+cliente, así que endurecer la regla **no afecta** el checkout real.
+
+**Corrección aplicada (este PR):**
+```
+// isValidSellData(): además de keys + storeId + total + name no vacío:
+request.resource.data.storeId is string &&
+request.resource.data.items.size() <= 100 &&
+request.resource.data.customer.name.size() <= 200
+```
+
+**Regresión:** `test/rules/firestore.rules.test.ts`:
+- "rechaza crear una venta con un array de items excesivo (SEC-01)"
+- "rechaza crear una venta con customer.name desmesuradamente largo (SEC-01)"
+- "permite 100 items (borde superior válido, SEC-01)"
+
+---
+
+## SEC-02 (Media) — 📄 documentado — `update` no fija `storeId` al path
+
+**Archivo:** `firestore.rules` (`products`/`sells` `update`)
+
+**Problema:** el `update` de `products` (y `sells`) gatea por `isStoreOwner` pero
+no re-verifica que `request.resource.data.storeId == storeId` (el del path). Un
+owner puede setear un `storeId` ajeno dentro de un documento de **su propia**
+tienda. No hay fuga cross-store (solo escribe en su path), pero corrompe la
+integridad referencial del campo.
+
+**Impacto:** bajo/medio, acotado a la propia tienda del owner.
+
+**Recomendación (no aplicada):** agregar `request.resource.data.storeId == storeId`
+a `create`/`update` de `products` (hoy solo lo hace `sells.create`).
+
+---
+
+## SEC-03 (Baja) — 📄 documentado — `isStoreOwner` inconsistente entre Firestore y Storage
+
+**Archivos:** `firestore.rules` (línea ~25) vs `storage.rules` (línea ~30)
+
+**Problema:** `firestore.rules` accede **directo** a `storeData.metadata.ownerId`,
+mientras que `storage.rules` usa el patrón seguro
+`.get('metadata', {}).get('ownerId', '')`.
+
+**Confirmado por test que NO es un bug funcional:** el test
+"reconoce al owner por metadata.ownerId (canónico actual)" siembra un store con
+**solo** `metadata.ownerId` (sin `ownerId`/`userId` raíz) y el owner **igual accede**.
+El operador `||` de las reglas absorbe el error de acceso a un campo raíz ausente y
+evalúa el tercer término. Es decir: la disponibilidad está OK; el riesgo es solo de
+**robustez/estilo** (fragilidad ante futuros cambios).
+
+**Recomendación (no aplicada):** alinear `firestore.rules` al patrón `.get(...)` de
+`storage.rules`.
+
+---
+
+## SEC-04 (Media) — 📄 documentado — roles `admin`/`employee` no soportados por reglas
+
+**Archivo:** `firestore.rules` (modelo de permisos)
+
+**Problema:** `isStoreOwner` solo reconoce al **owner**. Los roles `admin`/`employee`
+(documentados en CLAUDE.md como existentes pero "sin reglas específicas") no pueden
+acceder a los datos de la tienda vía reglas; el multi-usuario queda forzado a
+operar server-side con Admin SDK.
+
+**Recomendación (no aplicada):** al habilitar roles, modelar *membership* por tienda
+(p. ej. subcolección `/stores/{id}/members/{uid}`) y chequearla en las reglas.
+Decisión actual = consciente.
+
+---
+
+## SEC-05 (Baja) — 📄 documentado — `users/{uid}` sin validación de campos
+
+**Archivo:** `firestore.rules` (`users/{userId}`)
+
+**Problema:** `allow read, write` permite escribir campos arbitrarios sin validación
+ni tope de tamaño en el documento propio (self data corruption / abuso de storage).
+**No hay escalación de privilegios**: los permisos usan custom claims de Auth, no
+campos del documento de usuario.
+
+**Recomendación (no aplicada):** validar/acotar campos si el documento de usuario se
+vuelve sensible.
+
+---
+
+## Índices — sin gaps; sobre-aprovisionamiento menor
+
+No se detectaron índices **faltantes** para las queries de este repo (single-field,
+rango+orden sobre el mismo campo, o filtros in-memory). Los índices compuestos de
+`sells` por `payment.method`/`delivery.method`/`source` ya **no se usan** (los
+filtros se movieron a memoria en `sale.service.ts:131`) → candidatos a depuración
+futura. Detalle en [60-firebase-security-audit.md](../test/60-firebase-security-audit.md#4-índices-firestoreindexesjson-vs-queries-reales).
+
+> **Caveat:** el emulador no enforce índices compuestos; esta revisión es estática.
+
+---
+
+## Nota de tooling (no es un hallazgo de producto)
+
+- El entorno requería **Java** (JDK 21, igual que CI) para los emuladores de
+  Firestore/Storage. Las dependencias de dev (`vitest`, etc.) deben estar instaladas
+  (`npm install`) antes de correr `test:rules`.
+- Los tests de reglas viven en `test/rules/**/*.rules.test.ts` y comparten el runner
+  de integración (`vitest.integration.config.ts`). Se corren con `npm run test:rules`
+  (emulador arriba) o `npm run test:emu` (integración + reglas).

--- a/docs/marketing/instagram-launch-y-mejoras-visuales.md
+++ b/docs/marketing/instagram-launch-y-mejoras-visuales.md
@@ -1,0 +1,257 @@
+# Lanzamiento de Instagram + Mejoras Visuales — TuTiendaWeb
+
+**Fecha:** 2026-06-18 · **Mercado:** Argentina · **Audiencia:** gastronomía + pymes/retail (mix) · **Voseo argentino**
+
+> Documento de trabajo. Cruza el contexto real del producto (`docs/negocio/contexto-producto.md`), el `marketing-audit.md` (score 42/100, junio 2026) y la `guia-contenido-comercial.md` existente, y los traduce en un plan accionable para arrancar Instagram con buena base visual.
+
+---
+
+## 0. TL;DR — qué hacer primero
+
+1. **No lances Instagram apuntando a una casa rota.** El audit detectó CTAs a 404 (`/precios`, `/demo`), trial "7 días sin tarjeta" no implementado, testimonios ficticios y email Gmail. Cada visita que IG mande hoy a la landing se pierde o pierde confianza. **Arreglar eso es prerrequisito del lanzamiento** (ver §2).
+2. **Tu gancho ownable es el dinero, no la tecnología.** "PedidosYa se queda con el 30%. Nosotros, $15.000 fijos." Ese mensaje, aterrizado en pesos, es lo que más convierte y nadie lo puede copiar (ver §3).
+3. **Definí una identidad visual de feed consistente** (3 plantillas, paleta fija, tipografía) antes del post 1. La consistencia visual es lo que entrena al algoritmo y al ojo del usuario en 2026.
+4. **Reels primero.** Es el formato de mayor alcance; el cierre se hace por DM e Historias.
+5. Arrancá con los **12 posts de lanzamiento** (calendario de 4 semanas en §6) reutilizando la guía existente + las piezas nuevas de §7.
+
+---
+
+## 1. Diagnóstico visual actual (app + landing)
+
+Lo bueno: hay un **sistema de diseño definido** (violeta `#7C3AED`, sin gradientes, tinta plana, Plus Jakarta Sans, bordes redondeados, sombras suaves) y un hero con animaciones cuidadas (Framer Motion), badge de prueba gratis, tarjeta flotante "Nuevo pedido", mockups reales del celular. La base estética es sólida y coherente.
+
+Lo que conviene mejorar, en orden de impacto:
+
+| # | Problema visual | Por qué importa | Mejora concreta |
+|---|-----------------|-----------------|-----------------|
+| 1 | **Headline describe la herramienta, no el resultado** ("Digitalizá tu negocio") | El dueño no se identifica con "digitalizar" | "Tu negocio recibe pedidos por WhatsApp, 24/7, sin atender el teléfono" |
+| 2 | **Cero prueba social visible** en el primer scroll | Sin caras/números reales no hay confianza | Trust strip bajo el CTA: "+50 negocios ya usan TuTiendaWeb" + 1 testimonio real con nombre y rubro |
+| 3 | **Features en lenguaje de producto** ("Analytics y reportes", "Código QR") | No comunica beneficio | "Sabé qué producto te deja más plata" · "QR listo para imprimir, tus clientes ven el menú sin descargar nada" |
+| 4 | **Sin demostración del producto en movimiento** | El "cómo se ve" vende solo | GIF/video corto del catálogo real y del pedido llegando al WhatsApp, reutilizable también en IG |
+| 5 | **Catálogo público sin branding de TuTiendaWeb** ("Creado con…") | Cada catálogo compartido es publicidad gratis perdida | Footer "Creado con TuTiendaWeb — Creá tu tienda gratis" en cada `/carta/[url]` |
+| 6 | **Comparación de ahorro no es visual** | El número en pesos es el argumento estrella | Bloque/calculadora visual: comisión delivery (–30%) vs. precio fijo ($15.000) |
+
+> Nota sobre alcance del diseño: el **panel del dueño** tiene diseño fijo (sistema TuTiendaWeb). La **tienda pública** la personaliza cada comercio (logo, colores). Las mejoras visuales de marca aplican a landing, IG y materiales de marca — no a la tienda del cliente.
+
+---
+
+## 2. Antes de abrir la cuenta — checklist de credibilidad
+
+Instagram amplifica lo que ya tenés; si la base no cierra, amplifica el problema. Resolvé esto **antes o en paralelo** al primer post:
+
+- [ ] **Arreglar 404 de `/precios` y `/demo`** (o redirect 301 temporal a la home). Son CTAs primarios.
+- [ ] **Activar el trial real de 7 días** o cambiar la promesa por lo que sí se puede cumplir hoy.
+- [ ] **Eliminar/reemplazar testimonios ficticios** por 2-3 reales (aunque sean de la red del fundador, con nombre y rubro).
+- [ ] **Email corporativo** (`hola@tutiendaweb.com.ar`) en footer y bio.
+- [ ] **Bio de IG optimizada** (ver §4) con link a la landing (o Linktree con: probar gratis / ver demo / WhatsApp).
+- [ ] **WhatsApp Business** configurado con respuesta rápida y catálogo, ya que el cierre va por ahí.
+- [ ] **Foto de perfil = logo** sobre fondo blanco o violeta `#7C3AED`, legible en círculo chico.
+- [ ] **3-6 Historias destacadas** listas: "Qué es", "Cómo funciona", "Precio", "Demo", "Casos", "Preguntas".
+- [ ] **9 primeros posts** preparados antes de abrir (un perfil con grilla armada convierte más que uno vacío).
+
+---
+
+## 3. Posicionamiento y mensajes (la base de todo el contenido)
+
+**Categoría a apropiarse:** "el sistema de pedidos por WhatsApp para gastronomía y pymes argentinas" (no "catálogo digital" genérico).
+
+**Mensaje núcleo:** *Vendé por WhatsApp como siempre, pero ordenado y sin que nadie se quede con tu plata.*
+
+Mensajes de apoyo + prueba:
+
+| Mensaje | A qué dolor le pega | Prueba |
+|---------|---------------------|--------|
+| **Sin comisiones por venta** | La comisión de PedidosYa/Rappi (hasta 30%) | $200.000/mes en delivery apps = ~$60.000 que recuperás; con TuTiendaWeb pagás $15.000 fijos |
+| **Cero fricción para tu cliente** | El cliente no quiere descargar apps | Entra por link/QR, sin app ni registro |
+| **Pedidos ordenados, no caos** | Anotar en papel, errores, pedidos perdidos | Llega formateado al WhatsApp con datos, pago y entrega |
+| **Simple de verdad** | "No soy técnico" | "Si sabés usar WhatsApp, sabés usar esto" · tienda lista en 15 min |
+
+Diferenciador #1 para repetir siempre: **"PedidosYa se queda con el 30%. Nosotros, $15.000 fijos. Ese 30% es tuyo."**
+
+---
+
+## 4. Identidad visual para Instagram (lo que pediste: mejoras visuales)
+
+El objetivo es una **grilla reconocible de un vistazo**. Definí esto y no lo cambies:
+
+### Paleta (de la marca, fija)
+- **Violeta primario `#7C3AED`** — color dominante de marca.
+- **Azul `#2563eb`** — para destacar precios/números.
+- **Verde WhatsApp `#25D366`** — SOLO para la acción (botón/flechita "pedí acá"). Nunca decorativo.
+- **Neutros slate** (grises fríos) y blanco para respiro.
+- **Sin gradientes. Tinta plana siempre.**
+
+### Tipografía
+- **Plus Jakarta Sans** para todo (Poppins solo como display puntual en piezas de marketing).
+- Jerarquía clara: titular grande y grueso, bajada chica. Mucho espacio en blanco.
+
+### Sistema de plantillas (creá 3 en Canva y reutilizá)
+1. **Plantilla "Tip/Dato"** — fondo violeta o blanco, titular grande, 1 idea por placa. Para contenido educativo.
+2. **Plantilla "Producto/Captura"** — mockup de celular con catálogo real o captura del panel, sobre fondo plano de marca. Para mostrar el producto.
+3. **Plantilla "Comparación/Número"** — el número en pesos protagonista (ej: –30% vs $15.000), azul para la cifra. Para el argumento de ahorro.
+
+### Reglas de feed
+- **Fotos reales** de comida/comercios argentinos. Nada de stock genérico de oficina.
+- Portadas de Reels con **mismo formato** (franja de color + título consistente) → entrena al algoritmo y al ojo.
+- Patrón de grilla intencional (ej: alternar placa de marca / foto real / captura) para que el perfil se vea ordenado.
+- **Intro de 3 segundos repetida** en los Reels (misma cortina visual) para crear serie reconocible.
+
+### Bio sugerida
+```
+TuTiendaWeb 🛒
+Pedidos por WhatsApp, sin comisiones 🇦🇷
+Catálogo + QR para tu comercio o restaurante
+Probá gratis 7 días 👇
+[link: probar / demo / WhatsApp]
+```
+
+---
+
+## 5. Análisis competitivo (Argentina, 2026)
+
+| Factor | TuTiendaWeb | Tiendanube | MercadoShops | WhatsApp Business solo |
+|--------|-------------|------------|--------------|------------------------|
+| Precio entrada (ARS/mes) | **$15.000 fijo** | desde gratis; plan top ~$24.999 | Gratis | Gratis |
+| Comisión por venta | **0%** | 0,7%–2% s/plan (+ Pago Nube) | 6%–17% | 0% (informal) |
+| Pedidos por WhatsApp | ✅ Full, ordenado | ⚠️ Parcial | ❌ | ⚠️ Manual/caótico |
+| QR de catálogo | ✅ | ⚠️ | ❌ | ❌ |
+| Horarios abierto/cerrado | ✅ Único | ❌ | ❌ | ❌ |
+| Extras con precio (gastronomía) | ✅ Único | ⚠️ | ❌ | ❌ |
+| Sin app a descargar (cliente) | ✅ | ✅ | ✅ | ✅ |
+| Dominio propio | ❌ | ✅ | ❌ | ❌ |
+| App móvil nativa | ❌ (web ok) | ⚠️ | ✅ | ✅ |
+| Marca / prueba social pública | Baja | Muy alta | Alta | — |
+
+**Lectura para IG:** TuTiendaWeb gana en **costo real (0% comisión)**, **features gastronómicas** y **simplicidad WhatsApp-first**. Pierde en marca y prueba social — que es justamente lo que Instagram construye. La trinchera defendible y el ángulo de contenido: **nicho gastronómico argentino + ahorro vs. delivery apps**.
+
+**Huecos de mercado que nadie comunica bien (úsalos como contenido):**
+- "Alternativa a PedidosYa sin comisión" (búsqueda y dolor de altísima intención, sin dueño claro).
+- "Menú digital con QR para restaurantes" (Tiendanube no lo posiciona).
+- "Tu tienda no desaparece a las 24h" (vs. depender solo de Historias de IG).
+
+---
+
+## 6. Estrategia de contenido y calendario (primeras 4 semanas)
+
+### Pilares (regla 80/20: valor/entretenimiento vs. venta directa)
+1. **Educativo** — tips para vender más / trabajar menos (atrae y posiciona).
+2. **Producto en acción** — Reels mostrando lo fácil que es (convierte).
+3. **Prueba social** — capturas de pedidos reales, casos, testimonios (genera confianza).
+4. **Venta directa** — oferta, prueba gratis, ahorro vs. comisiones (cierra).
+
+### Formatos por objetivo (Instagram 2026)
+- **Reels** = alcance y descubrimiento (formato prioritario; el alcance general cayó ~30% interanual, así que la calidad y los primeros 3 seg importan más que nunca).
+- **Carruseles** = educación y guardado (excelente para tips y comparaciones).
+- **Historias** = cercanía, encuestas, microdecisiones y empuje a DM.
+- **DM** = donde se cierra la venta. Llevá siempre la conversación ahí.
+
+### Cadencia inicial realista
+3–4 publicaciones/semana en feed (mínimo 2 Reels) + Historias casi diarias (encuestas, behind the scenes, repost de clientes).
+
+### Calendario semana a semana
+
+| Semana | Pieza | Formato | Pilar | Notas / dependencia |
+|--------|-------|---------|-------|---------------------|
+| 1 | Presentación del perfil | Carrusel 3 | Producto | Abre el perfil. Requiere bio + destacadas listas |
+| 1 | "Armá tu tienda en 2 min" | Reel | Producto | Screen recording real |
+| 1 | "PedidosYa se queda con el 30%" | Carrusel/placa | Venta | Plantilla "Comparación/Número" |
+| 1 | Encuesta en Historias: "¿Cuánto pagás de comisión?" | Historia | Educativo | Empuja a DM |
+| 2 | "3 errores al vender por WhatsApp" | Carrusel | Educativo | Alto guardado |
+| 2 | Pedido llegando ordenado al WhatsApp | Reel | Producto | Mostrar el mensaje formateado |
+| 2 | Caso/testimonio real (rubro gastronómico) | Carrusel/foto | Prueba social | Requiere 1 cliente real |
+| 3 | "Menú con QR en la mesa" (cafetería/resto) | Reel | Producto | Mostrar QR escaneándose |
+| 3 | "Tu tienda no desaparece a las 24h" (vs. Historias) | Carrusel | Educativo | Para emprendedor de IG |
+| 3 | Calculadora de ahorro (qué ahorrás según facturación) | Carrusel | Venta | Pone el número en pesos |
+| 4 | Reel rubro retail (ropa/almacén) cargando productos | Reel | Producto | Mostrar carga masiva Excel |
+| 4 | "7 días gratis, sin tarjeta" + CTA fuerte | Reel/placa | Venta | Requiere trial activo (ver §2) |
+
+Dejá ~20% de los slots libres para contenido reactivo (responder dudas frecuentes, repostear clientes).
+
+---
+
+## 7. Ideas de posts listos para usar
+
+> Reemplazá `[corchetes]` con datos reales. Los emojis son parte del copy.
+
+### POST A — Carrusel "El número que no ves" (venta, ahorro)
+**📸 Visual:** Plantilla "Comparación/Número". Slide 1: "¿Sabés cuánta plata te llevan las apps de delivery?" Slide 2: "Si facturás $200.000/mes… te quedás con $140.000" (–30% en rojo). Slide 3: "Con TuTiendaWeb pagás $15.000 fijos. El resto es tuyo." (cifra en azul `#2563eb`).
+**✍️ Caption:**
+> Hagamos la cuenta 🧮
+> PedidosYa y Rappi te cobran hasta 30% por pedido.
+> Si vendés $200.000 al mes, son ~$60.000 que no ves nunca.
+> Con TuTiendaWeb pagás $15.000 fijos. Sin comisiones. Ese 30% vuelve a tu bolsillo. 💸
+> Probá gratis 7 días 👉 link en bio.
+**#️⃣** #gastronomiaargentina #pymesargentina #delivery #emprendedoresargentina #whatsappbusiness
+
+### POST B — Reel "El pedido llega solo, ordenado" (producto)
+**📹 Video (9:16, 20-30s):** pantalla partida — izquierda: cliente arma el pedido en el catálogo; derecha: el mensaje llega formateado al WhatsApp del dueño. Texto en pantalla: "Tu cliente arma el pedido…" → "…y te llega ordenado, con todo." Música alegre.
+**✍️ Caption:**
+> Se terminó anotar pedidos en papel 📝❌
+> Tu cliente elige, suma los extras y te manda el pedido armado: productos, datos, pago y entrega. Todo ordenado en tu WhatsApp.
+> Vos solo confirmás y preparás. ✅
+> 👉 7 días gratis, link en bio.
+**#️⃣** #catalogodigital #menudigital #whatsappbusiness #rotiseria #hamburgueseria
+
+### POST C — Carrusel educativo "3 errores al vender por WhatsApp" (educativo, guardado)
+**📸 Visual:** Plantilla "Tip/Dato", 1 error por slide + slide final de marca.
+**✍️ Caption:**
+> 3 cosas que te están haciendo perder ventas por WhatsApp 👇
+> 1️⃣ Contestar "¿qué tenés?" 50 veces por día → poné un catálogo con fotos y precios.
+> 2️⃣ Anotar pedidos a mano → que lleguen ordenados solos.
+> 3️⃣ Vivir de las Historias que desaparecen → tené un link fijo que vende 24/7.
+> Guardá este post 📌 y arreglá el #1 hoy.
+**#️⃣** #tipsventas #emprendedores #pymesargentina #negociopropio
+
+### POST D — Reel "Tu tienda en 2 minutos" (producto, demo)
+**📹 Video (9:16, 30-40s):** screen recording armando una tienda de cero: crear cuenta → cargar 2 productos con foto → compartir el link. Texto por escena: "Mirá lo fácil 👇" / "Cargás producto, foto y precio" / "Compartís el link" / "Tu cliente ya puede pedir 🎉".
+**✍️ Caption:**
+> Tu tienda online lista en menos de lo que tardás en hacer un café ☕
+> Sin saber nada de tecnología. Si usás WhatsApp, sabés usar esto.
+> 👉 7 días gratis, sin tarjeta. Link en bio.
+**#️⃣** #catalogodigital #menudigital #emprendedoresargentina #whatsappbusiness
+
+### POST E — Carrusel "Para el que vende por Instagram" (educativo + venta, nicho retail)
+**📸 Visual:** Plantilla "Tip/Dato". Slide 1: "Vendés por Instagram pero tus Historias desaparecen a las 24h 😪". Slide 2: "Tu catálogo en TuTiendaWeb queda fijo, con link en tu bio." Slide 3: "Tus clientes piden cuando quieran, vos no perdés ninguno."
+**✍️ Caption:**
+> Si vendés por Instagram esto es para vos 📲
+> Las Historias se van a las 24h y con ellas las ventas que no llegaste a contestar.
+> Armá un catálogo fijo, ponelo en tu bio y que te pidan a cualquier hora — directo a tu WhatsApp, sin comisiones.
+> 👉 Probalo gratis, link en bio.
+**#️⃣** #emprendedoraargentina #tiendaonline #ventaporinstagram #pymes #indumentaria
+
+> La `guia-contenido-comercial.md` del repo ya tiene 12 posts de lanzamiento listos — combinalos con estos 5 para cubrir las 4 semanas sin repetir.
+
+---
+
+## 8. Métricas y seguimiento
+
+**Objetivo del primer trimestre:** construir audiencia + generar inicios de prueba (no obsesionarse con ventas directas el mes 1).
+
+| Métrica | Qué mide | Meta inicial (90 días) |
+|---------|----------|------------------------|
+| Seguidores | Construcción de audiencia | +500–1.000 |
+| Alcance de Reels | Descubrimiento | Identificar 2-3 Reels "ganadores" para repetir formato |
+| Guardados/compartidos | Valor del contenido educativo | Crece semana a semana |
+| Clics al link de bio | Intención | Trackear con UTM o Linktree |
+| Conversaciones por DM | Intención de compra | El indicador que más importa |
+| Inicios de prueba desde IG | Conversión | UTM `?utm_source=instagram` en el link |
+
+**Cadencia:** revisar números 1 vez por semana. Duplicar lo que funciona (formato, gancho, horario), cortar lo que no.
+
+---
+
+## 9. Próximos pasos inmediatos
+
+1. **Resolver el checklist de credibilidad (§2)** — bloquea todo lo demás.
+2. **Crear las 3 plantillas de Canva (§4)** y la foto de perfil + destacadas.
+3. **Grabar 2 screen recordings** (armar tienda / pedido llegando) → base de los primeros Reels.
+4. **Conseguir 1-2 casos reales** para los posts de prueba social.
+5. **Cargar los 9 primeros posts** y recién ahí abrir/anunciar la cuenta.
+6. (Recomendado) Activar el **loop viral**: "Creado con TuTiendaWeb" en cada catálogo público — es el canal de adquisición de mayor ROI y refuerza todo lo de IG.
+
+---
+
+### Fuentes
+- Material interno del repo: `docs/marketing/marketing-audit.md`, `docs/negocio/contexto-producto.md`, `docs/marketing/guia-contenido-comercial.md`.
+- [Planes y costos de Tiendanube Argentina 2026](https://mktmarketingdigital.com/planes-costos-tienda-nube-argentina-2026/) · [Comisiones Pago Nube](https://ayuda.tiendanube.com/es_ES/pago-nube/cuales-son-las-comisiones-de-pago-nube)
+- [Cómo funciona el algoritmo de Instagram en 2026](https://www.optimaweb.es/como-funciona-algoritmo-instagram/) · [Redes sociales 2026: estrategia según datos (IEBS)](https://www.iebschool.com/hub/redes-sociales-2026-estrategia-datos/)

--- a/docs/test/30-rules-audit-guide.md
+++ b/docs/test/30-rules-audit-guide.md
@@ -85,8 +85,10 @@ informe (hallazgos, severidad, recomendaciones) se vuelca en
 También se revisa `firestore.indexes.json` contra las queries reales detectadas
 en Fase 2 para detectar índices faltantes.
 
-## Criterio de salida (Fase 3)
+## Criterio de salida (Fase 3) — ✅ cumplido (2026-06-19)
 
-- Matriz allow/deny completa, toda verde.
-- Informe de auditoría escrito en `60-...md`.
-- Lista de gaps de índices (si los hay).
+- ✅ Matriz allow/deny completa, toda verde (81 tests, `test/rules/*.rules.test.ts`).
+- ✅ Informe de auditoría escrito en [`60-firebase-security-audit.md`](./60-firebase-security-audit.md) (puntaje 3/5).
+- ✅ Lista de gaps de índices (sin faltantes; sobre-aprovisionamiento menor documentado).
+- ✅ Hallazgo de seguridad alto (SEC-01) corregido; resto documentado.
+- ✅ CI corre reglas en el job `emulators`.

--- a/docs/test/60-firebase-security-audit.md
+++ b/docs/test/60-firebase-security-audit.md
@@ -1,66 +1,152 @@
 # 60 · Auditoría de seguridad Firebase
 
-> **Estado:** pendiente — se completa en la **Fase 3** con la skill
-> `firebase-security-rules-auditor` y los resultados de los tests de reglas.
+> **Estado:** ✅ completada en la **Fase 3** (2026-06-19). Tests de reglas verdes
+> (`test/rules/*.rules.test.ts`, 81 casos) + auditoría con la skill
+> `firebase-security-rules-auditor`.
 
-Este documento recopilará los hallazgos de la auditoría de seguridad sobre
-`firestore.rules`, `storage.rules` y `firestore.indexes.json`.
-
-## Estructura prevista del informe
-
-### 1. Resumen ejecutivo
-Estado general de robustez de las reglas y cantidad de hallazgos por severidad.
-
-### 2. Hallazgos
-Por cada hallazgo:
-
-| Campo | Contenido |
-|-------|-----------|
-| ID | `SEC-NN` |
-| Severidad | Crítica / Alta / Media / Baja |
-| Recurso | colección o ruta afectada |
-| Descripción | qué permite indebidamente o qué valida de más/menos |
-| Evidencia | test que lo demuestra (`*.rules.test.ts`) |
-| Recomendación | cambio propuesto (no se aplica sin aprobación) |
-
-### 3. Cobertura de la matriz allow/deny
-Checklist de la matriz de [30-rules-audit-guide](./30-rules-audit-guide.md) con
-su estado (verde/rojo).
-
-### 4. Índices
-Gaps detectados entre `firestore.indexes.json` y las queries reales (Fase 2).
-
-### 5. Modelo de datos / claims
-Observaciones sobre custom claims (`storeId`, `role`) y consistencia
-`ownerId`/`userId`/`metadata.ownerId`.
+Auditoría de seguridad sobre `firestore.rules`, `storage.rules` y
+`firestore.indexes.json`. La evidencia de cada regla son los tests de la Fase 3
+([test/rules/firestore.rules.test.ts](../../test/rules/firestore.rules.test.ts),
+[test/rules/storage.rules.test.ts](../../test/rules/storage.rules.test.ts)).
 
 ---
 
-## Hallazgos de validación (Fase 1)
+## 1. Resumen ejecutivo
+
+**Puntaje skill: 3/5 (Moderado).** Base sólida, sin fugas de datos ni escalación
+de privilegios:
+
+- Ownership **estricto** por owner; la autoridad se toma del documento almacenado
+  (`get()` del recurso existente), **no** de `request.resource.data` provisto por
+  el cliente.
+- Catch-all `deny` correcto en Firestore y Storage.
+- Lectura pública acotada al catálogo (`stores`, `products`, `categories`, `tags`)
+  y a las imágenes públicas; el resto (ventas, settings, notificaciones, usuarios)
+  es privado.
+- `create` y `update` re-validan con la misma función en `products`/`categories`/`tags`
+  (no hay "update bypass" de validación).
+
+El punto débil es la **única escritura pública** (`sells.create`, sin auth): se
+endureció en este PR (SEC-01) agregando topes de tamaño/tipo. El resto de los
+hallazgos son de severidad media/baja y quedan **documentados** (sin cambiar reglas)
+según la política del proyecto.
+
+| Severidad | Cantidad | Acción |
+|-----------|:---:|--------|
+| Crítica | 0 | — |
+| Alta / Major | 1 (SEC-01) | ✅ corregida en este PR |
+| Media / Moderate | 2 (SEC-02, SEC-04) | documentada |
+| Baja / Minor | 2 (SEC-03, SEC-05) | documentada |
+
+---
+
+## 2. Hallazgos
+
+| ID | Severidad | Recurso | Descripción | Evidencia | Recomendación |
+|----|-----------|---------|-------------|-----------|---------------|
+| **SEC-01** | Alta (Major) | `firestore.rules` → `isValidSellData()` / `sells.create` | `sells.create` es la única escritura **pública (sin auth)**. La validación exigía keys, `storeId` del path, `total>=0` y `customer.name` no vacío, pero **no acotaba tamaños**: `items` podía ser un array enorme y `customer.name` un string ilimitado. Un atacante anónimo que golpee Firestore directamente (salteándose la app) podía crear documentos de venta gigantes/masivos → *resource exhaustion*/costos y contaminación del dashboard del comercio. | `test/rules/firestore.rules.test.ts` → "rechaza … array de items excesivo (SEC-01)", "customer.name desmesuradamente largo (SEC-01)", "permite 100 items (borde válido)". | **✅ RESUELTO en este PR.** Se agregó `items.size() <= 100`, `customer.name.size() <= 200` y `storeId is string` a `isValidSellData()`. La ruta legítima usa Admin SDK (bypasea reglas), así que no afecta el checkout real. Ver [hallazgos](../hallazgos/testing-fase3-2026-06-19.md#sec-01). |
+| **SEC-02** | Media | `firestore.rules` → `products`/`sells` update | El `update` gatea por `isStoreOwner` pero **no re-verifica** que `data.storeId == storeId` (el path). Un owner puede setear un `storeId` ajeno dentro de su propio documento. Alcance limitado a su propia tienda (no hay leak cross-store), pero corrompe integridad referencial. | (no se fuerza un caso de éxito malicioso; documentado) | Exigir `request.resource.data.storeId == storeId` en `create`/`update` de `products` (hoy solo lo hace `sells.create`). No bloqueante. |
+| **SEC-03** | Baja | `firestore.rules` → `isStoreOwner` | Accede **directo** a `storeData.metadata.ownerId`, mientras que `storage.rules` usa el patrón seguro `.get('metadata', {}).get('ownerId', '')`. Los tests confirman que **funciona igual** (el `\|\|` de las reglas absorbe el error de campo ausente y reconoce al owner por `metadata.ownerId` aunque falten los campos raíz), así que **no es un bug funcional**, pero es inconsistente y frágil. | `test/rules/firestore.rules.test.ts` → "reconoce al owner por metadata.ownerId", "…por userId (legacy)". | Alinear `firestore.rules` al patrón `.get(...)` de `storage.rules` por robustez. No bloqueante. |
+| **SEC-04** | Media | `firestore.rules` (modelo) | `isStoreOwner` solo reconoce al **owner**; los roles `admin`/`employee` (documentados en CLAUDE.md) **no** tienen acceso vía reglas. El multi-usuario queda forzado a workarounds server-side (Admin SDK). | (gap de diseño; no hay test) | Al habilitar roles, modelar *membership* por tienda en las reglas (p. ej. `/stores/{id}/members/{uid}`). Decisión actual documentada como consciente. |
+| **SEC-05** | Baja | `firestore.rules` → `users/{uid}` | `allow read, write` permite escribir **campos arbitrarios sin validación ni tope** en el doc propio (self data corruption / abuso de storage). **No hay escalación**: los permisos usan custom claims de Auth, no campos del doc. | `test/rules/firestore.rules.test.ts` → casos `users/{userId}` (acceso propio ✓, ajeno/anónimo ✗). | Validar/acotar campos del documento de usuario si se vuelve sensible. No bloqueante. |
+
+> Las "áreas de atención pre-auditoría" listadas históricamente quedan **cerradas**:
+> el soporte de 3 campos de ownership no habilita acceso cruzado (test de
+> no-cross-store ✓); `sells.create` valida estructura, `storeId` y ahora tamaños
+> (SEC-01); el tope de 5 MB y `image/*` de Storage está verificado con tests de
+> archivo grande y no-imagen.
+
+---
+
+## 3. Cobertura de la matriz allow/deny
+
+Matriz de [30-rules-audit-guide](./30-rules-audit-guide.md) — **toda verde** (cada
+`allow` con su espejo `deny`).
+
+### Firestore
+
+| Recurso | Permitido ✓ | Denegado ✓ |
+|---------|:---:|:---:|
+| `stores/{id}` read (público) | ✅ | — |
+| `stores/{id}` write (owner) | ✅ | ✅ no-owner / anónimo |
+| `products`/`categories`/`tags` read (público) | ✅ | — |
+| `products`/`categories`/`tags` create/update (owner+válida) | ✅ | ✅ no-owner / data inválida |
+| `products`/`categories`/`tags` delete (owner) | ✅ | ✅ no-owner |
+| `products` price (req./numérico/≥0/0 borde) | ✅ | ✅ falta/negativo/no-num |
+| `sells` create (anónimo + válida + storeId) | ✅ | ✅ items vacío/total<0/storeId ajeno/falta key/name vacío/**tamaños** |
+| `sells` read/update/delete (owner) | ✅ | ✅ anónimo / no-owner |
+| `settings` read/write (owner) | ✅ | ✅ anónimo / no-owner |
+| `notifications` read/update (owner) | ✅ | — |
+| `notifications` create/delete (nadie) | — | ✅ owner |
+| `users/{uid}` read/write (propio) | ✅ | ✅ otro uid / anónimo |
+| catch-all | — | ✅ todo |
+| Ownership por `ownerId`/`userId`/`metadata.ownerId` | ✅ | ✅ no cross-store |
+
+### Storage
+
+| Ruta | Permitido ✓ | Denegado ✓ |
+|------|:---:|:---:|
+| `stores/{id}/**` read (público) | ✅ | — |
+| `stores/{id}/**` write (owner+imagen) | ✅ | ✅ no-owner / >5MB / no-imagen |
+| `stores/{id}/**` delete (owner) | ✅ | ✅ no-owner |
+| `users/{uid}/avatar/**` (propio+imagen) | ✅ | ✅ otro uid / no-imagen / anónimo |
+| `temp/{uid}/**` (propio+imagen) | ✅ | ✅ otro uid |
+| catch-all | — | ✅ todo |
+
+---
+
+## 4. Índices (`firestore.indexes.json` vs queries reales)
+
+**No se detectaron índices faltantes** para las queries de este repo:
+
+- `getSales` ([sale.service.ts:110](../../src/features/dashboard/modules/sells/services/sale.service.ts#L110))
+  ordena por `metadata.createdAt` y filtra por rango **sobre el mismo campo** →
+  no requiere índice compuesto. Los filtros por `paymentMethod`/`source` se hacen
+  **in-memory** (comentario explícito en `sale.service.ts:131`).
+- Queries de `store.service`/`public-store.service` son `==` de un solo campo o dos
+  `==` (resueltos por índices de campo único, sin compuesto) y `slug ==` (único).
+- `getCategoryUsage` usa `count()` sobre `==` simples.
+
+**Observación (no bloqueante):** hay índices compuestos en `sells`
+(`payment.method`+`metadata.createdAt`, `delivery.method`+`metadata.createdAt`,
+`source`+`metadata.createdAt`) que **ya no usa** la app (los filtros se movieron a
+memoria). Son sobre-aprovisionamiento; pueden depurarse a futuro. El índice de
+`stores` (`subscription.active`+`subscription.endDate`) sirve al repo de Cloud
+Functions (suscripciones), fuera del alcance de este repo.
+
+> **Caveat metodológico:** el emulador de Firestore **no enforce** índices
+> compuestos, así que los tests de integración verdes **no** prueban completitud de
+> índices. Esta sección es análisis estático de las queries, no resultado de tests.
+
+---
+
+## 5. Modelo de datos / claims
+
+- **Ownership (3 campos):** `ownerId` (raíz, legacy), `userId` (raíz, legacy) y
+  `metadata.ownerId` (canónico). Verificado que cualquiera de los tres reconoce al
+  owner y que **no** habilita acceso cruzado entre tiendas (test de no-cross-store).
+  Recomendación: ver SEC-03 (alinear el acceso seguro) y consolidar a `metadata.ownerId`
+  cuando termine la migración.
+- **Custom claims (`storeId`, `role`):** los permisos del dashboard se resuelven
+  server-side con `getServerSession()` + reglas por owner. `role` `admin`/`employee`
+  aún sin reglas (SEC-04).
+- **`getServerSession`** verifica el token con `verifyIdToken(token, false)` (sin
+  chequeo de revocación): trade-off consciente (tolerancia ~1 h hasta refresco de
+  claims). Documentado como decisión, no es hallazgo de reglas.
+
+---
+
+## Apéndice · Hallazgos históricos (Fases 1–2)
+
+### Validación (Fase 1)
 
 | ID | Severidad | Archivo | Descripción | Recomendación |
 |----|-----------|---------|-------------|---------------|
-| `VAL-01` | Baja | `auth/schemas/login.schema.ts`, `register.schema.ts` | El email encadena `.email()` **antes** de `.trim()`, por lo que un email con espacios alrededor se **rechaza** en vez de recortarse (el `.trim()` no afecta la validación). | Reordenar a `.trim().toLowerCase().email()` para que el trim sea efectivo antes de validar. No se aplica sin aprobación; documentado en los tests como comportamiento actual. |
+| `VAL-01` | Baja | `auth/schemas/login.schema.ts`, `register.schema.ts` | El email encadena `.email()` **antes** de `.trim()`, por lo que un email con espacios alrededor se **rechaza** en vez de recortarse. | Reordenar a `.trim().toLowerCase().email()`. Documentado; no se aplica sin aprobación. |
 
-## Hallazgos de integración (Fase 2)
+### Integración (Fase 2)
 
-| ID | Severidad | Archivo | Descripción | Recomendación |
-|----|-----------|---------|-------------|---------------|
-| `INT-01` | Media | `store/services/checkout.service.ts` (`buildTrustedSale`), `dashboard/modules/sells/services/sale.service.ts` (`createSale`), `dashboard/modules/sells/schemas/sell.schema.ts` (`saleTotalsSchema`) | El costo de envío **no quedaba persistido** en la venta. `buildTrustedSale` armaba `saleData.totals.total = subtotal + deliveryFee`, pero `createSale` lo **recalculaba** como `total = subtotal - discount`, descartando el envío; además `saleTotalsSchema` no tenía campo `deliveryFee`. En pedidos `delivery`, la venta guardada quedaba con `total = subtotal` y `calculateSalesStats` **subcontaba** los envíos. | **✅ RESUELTO (PR2, 2026-06-17).** Decisión: el envío integra el total. Se agregó `deliveryFee` a `saleTotalsSchema` (`default(0)`), `buildTrustedSale` lo incluye en `saleData.totals`, `createSale`/`updateSale` calculan `total = subtotal − discount + deliveryFee` y lo persisten, y `mapDocToSale` lo mapea (default 0 para ventas previas). Regresión: `checkout.int.test.ts` (delivery) + `sells.int.test.ts`. Detalle en [docs/hallazgos/testing-fase2-2026-06-17.md](../hallazgos/testing-fase2-2026-06-17.md). |
-| `INT-02` | Baja | `dashboard/modules/sells/services/sale.service.ts` (`updateSale`) | Al actualizar una venta **cambiando `items` pero sin pasar `totals`**, el descuento se tomaba como `data.totals?.discount ?? 0`: un descuento ya guardado se **reseteaba a 0** en el recálculo del total (el envío sí se preservaba tras INT-01; el descuento no). | **✅ RESUELTO (PR2, 2026-06-17).** `updateSale` ahora hace fallback del descuento (y del envío) al valor ya persistido cuando no viene en el payload: `discount = data.totals?.discount ?? existingTotals?.discount ?? 0`. Regresión en `sells.int.test.ts` → "preserva el descuento existente al reemplazar items sin enviar totals (INT-02)". Detalle en [docs/hallazgos/testing-fase2-2026-06-17.md](../hallazgos/testing-fase2-2026-06-17.md). |
-
-## Áreas de atención ya identificadas (pre-auditoría)
-
-De la exploración inicial, a confirmar/validar con tests en Fase 3:
-
-- `isStoreOwner` soporta **3 campos** de ownership (`ownerId`, `userId`,
-  `metadata.ownerId`) para migración gradual. Verificar que ninguno habilite
-  accesos cruzados entre tiendas.
-- `sells.create` es **público** (sin auth) por diseño (checkout). Confirmar que
-  `isValidSellData()` impide inyección de ventas malformadas o con `storeId`
-  ajeno, y que `total`/`items` se validan.
-- `getServerSession` verifica el token con `verifyIdToken(token, false)` (sin
-  chequear revocación) — documentar el trade-off (tolerancia ~1h) como decisión
-  consciente.
-- Storage: límite de 5MB y `contentType image/*` — confirmar con tests de archivo
-  grande y de no-imagen.
+| ID | Severidad | Archivo | Descripción | Estado |
+|----|-----------|---------|-------------|--------|
+| `INT-01` | Media | `checkout.service.ts`, `sale.service.ts`, `sell.schema.ts` | El costo de envío no quedaba persistido en la venta (`createSale` recalculaba `total = subtotal − discount` descartando el envío). | **✅ RESUELTO (PR2).** El envío integra el total; `deliveryFee` agregado al schema y a los recálculos. Detalle en [testing-fase2-2026-06-17.md](../hallazgos/testing-fase2-2026-06-17.md). |
+| `INT-02` | Baja | `sale.service.ts` (`updateSale`) | Al editar items sin enviar `totals`, el descuento se reseteaba a 0. | **✅ RESUELTO (PR2).** Fallback del descuento/envío al valor persistido. |

--- a/docs/test/README.md
+++ b/docs/test/README.md
@@ -80,7 +80,11 @@ npm run test:e2e:ui   # E2E modo interactivo
   - **Store-settings** ✅ PR5 — slug único case-insensitive, validación por sección. `test/integration/store-settings.int.test.ts`.
   - **Auth/claims** ✅ PR6 — `setUserClaims`/`getUserClaims`, `getServerSession` (claims/fallback). `test/integration/auth.int.test.ts`.
   - **Pendiente (no bloqueante):** gate cuantitativo de cobertura de integración (se enforcea en Fase 5).
-- **Fase 3** — Auditoría de reglas Firestore/Storage.
+- **Fase 3** — Auditoría de reglas Firestore/Storage. ✅ **81 tests verdes** (`npm run test:rules`).
+  - **Reglas Firestore** ✅ `test/rules/firestore.rules.test.ts` — matriz allow/deny completa (stores, products/categories/tags, sells, settings, notifications, users, catch-all) + ownership por los 3 campos legacy sin acceso cruzado.
+  - **Reglas Storage** ✅ `test/rules/storage.rules.test.ts` — `stores/**` (público read; owner+imagen<5MB write/delete), `users/{uid}/avatar`, `temp/{uid}`, catch-all.
+  - **Auditoría** (skill `firebase-security-rules-auditor`): puntaje 3/5, informe en [`60-firebase-security-audit.md`](./60-firebase-security-audit.md). **SEC-01** (escritura pública `sells.create` sin topes de tamaño) **corregido** en este PR; SEC-02..05 documentados. Hallazgos en [`hallazgos/testing-fase3-2026-06-19.md`](../hallazgos/testing-fase3-2026-06-19.md).
+  - **Índices:** sin gaps; sobre-aprovisionamiento menor en `sells` (filtros movidos a memoria). CI corre integración + reglas en el job `emulators`.
 - **Fase 4** — E2E de los 6 flujos críticos.
 - **Fase 5** — Gates de cobertura en CI y cierre de documentación.
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -31,18 +31,28 @@ service cloud.firestore {
     // públicas se crean desde el Server Action `createPublicSaleAction` usando
     // el Admin SDK, que bypasea estas reglas. La validación primaria ocurre
     // en el Server Action con Zod (checkoutFormSchema + sell.schema.ts).
+    //
+    // Como `sells.create` es la única escritura PÚBLICA (sin auth), además de las
+    // keys y el storeId se imponen topes de tamaño/tipo (SEC-01) para evitar que
+    // un atacante anónimo que golpee Firestore directamente cree documentos
+    // gigantes o masivos (resource exhaustion) o contamine el dashboard del
+    // comercio. La ruta legítima (Admin SDK) no pasa por aquí, así que estos
+    // límites no afectan al checkout real.
     function isValidSellData() {
       return request.resource.data.keys().hasAll([
                'orderNumber', 'storeId', 'source',
                'customer', 'items', 'delivery',
                'payment', 'totals', 'metadata'
              ]) &&
+             request.resource.data.storeId is string &&
              request.resource.data.items is list &&
              request.resource.data.items.size() > 0 &&
+             request.resource.data.items.size() <= 100 &&
              request.resource.data.totals.total is number &&
              request.resource.data.totals.total >= 0 &&
              request.resource.data.customer.name is string &&
-             request.resource.data.customer.name.size() > 0;
+             request.resource.data.customer.name.size() > 0 &&
+             request.resource.data.customer.name.size() <= 200;
     }
 
     function isValidProductData() {

--- a/test/rules/firestore.rules.test.ts
+++ b/test/rules/firestore.rules.test.ts
@@ -1,0 +1,483 @@
+/**
+ * Tests de reglas de seguridad de Firestore (Fase 3).
+ *
+ * Evalúa `firestore.rules` con `@firebase/rules-unit-testing` contra el
+ * emulador. Cada `allow` tiene su espejo `deny` (criterio de aceptación F).
+ *
+ * Contextos:
+ *  - `env.unauthenticatedContext()` → anónimo (catálogo público / checkout).
+ *  - `env.authenticatedContext(uid)` → usuario logueado (owner vs intruso).
+ *
+ * El setup (sembrar datos saltándose las reglas) usa
+ * `env.withSecurityRulesDisabled(...)`. Cada test parte de Firestore limpio
+ * (`env.clearFirestore()` en beforeEach).
+ *
+ * Guía: docs/test/30-rules-audit-guide.md
+ */
+import { assertFails, assertSucceeds } from '@firebase/rules-unit-testing';
+import type { RulesTestEnvironment } from '@firebase/rules-unit-testing';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  cleanupRulesTestEnv,
+  getRulesTestEnv,
+} from '../helpers/firebase-emulator';
+import {
+  makeCategory,
+  makeProduct,
+  makeSale,
+  makeStore,
+  TEST_OWNER_UID,
+  TEST_STORE_ID,
+} from '../helpers/factories';
+
+const INTRUDER_UID = 'intruso-uid';
+const OTHER_STORE_ID = 'otra-tienda';
+
+let env: RulesTestEnvironment;
+
+/** Firestore del owner legítimo de la tienda demo. */
+const ownerDb = () => env.authenticatedContext(TEST_OWNER_UID).firestore();
+/** Firestore de un usuario autenticado que NO es owner. */
+const intruderDb = () => env.authenticatedContext(INTRUDER_UID).firestore();
+/** Firestore anónimo (catálogo público / checkout). */
+const anonDb = () => env.unauthenticatedContext().firestore();
+
+/** Siembra documentos saltándose las reglas (setup). */
+async function seed(fn: (db: FirebaseFirestore.Firestore) => Promise<void>) {
+  await env.withSecurityRulesDisabled(async (ctx) => {
+    // El tipo del contexto deshabilitado expone un firestore() compatible.
+    await fn(ctx.firestore() as unknown as FirebaseFirestore.Firestore);
+  });
+}
+
+/** Una venta pública válida según `isValidSellData()` (incluye `metadata`). */
+const makeValidSell = (over: Record<string, unknown> = {}) =>
+  makeSale({ metadata: { createdAt: Date.now() }, ...over });
+
+beforeAll(async () => {
+  env = await getRulesTestEnv();
+});
+
+afterAll(async () => {
+  await cleanupRulesTestEnv();
+});
+
+beforeEach(async () => {
+  await env.clearFirestore();
+  // La mayoría de las reglas (isStoreOwner) consultan el doc /stores/{id}.
+  await seed(async (db) => {
+    await db.doc(`stores/${TEST_STORE_ID}`).set(makeStore());
+  });
+});
+
+// =============================================================================
+// stores/{id}
+// =============================================================================
+
+describe('stores/{storeId}', () => {
+  it('permite la lectura pública (catálogo) a un usuario anónimo', async () => {
+    await assertSucceeds(anonDb().doc(`stores/${TEST_STORE_ID}`).get());
+  });
+
+  it('permite al owner modificar su tienda', async () => {
+    await assertSucceeds(
+      ownerDb()
+        .doc(`stores/${TEST_STORE_ID}`)
+        .set(makeStore({ basicInfo: { name: 'Nuevo nombre' } })),
+    );
+  });
+
+  it('rechaza que un usuario no-owner modifique la tienda', async () => {
+    await assertFails(
+      intruderDb().doc(`stores/${TEST_STORE_ID}`).update({ x: 1 }),
+    );
+  });
+
+  it('rechaza que un usuario anónimo modifique la tienda', async () => {
+    await assertFails(anonDb().doc(`stores/${TEST_STORE_ID}`).update({ x: 1 }));
+  });
+});
+
+// =============================================================================
+// Ownership — isStoreOwner soporta 3 campos legacy
+// =============================================================================
+
+describe('isStoreOwner — campos de ownership', () => {
+  it('reconoce al owner por el campo raíz ownerId', async () => {
+    await seed(async (db) => {
+      await db
+        .doc(`stores/${TEST_STORE_ID}`)
+        .set(makeStore({ ownerId: TEST_OWNER_UID, metadata: { status: 'active' } }));
+    });
+    await assertSucceeds(
+      ownerDb().doc(`stores/${TEST_STORE_ID}/products/p1`).set(makeProduct()),
+    );
+  });
+
+  it('reconoce al owner por el campo raíz userId (legacy)', async () => {
+    await seed(async (db) => {
+      // Sin ownerId raíz ni metadata.ownerId: solo userId.
+      await db.doc(`stores/${TEST_STORE_ID}`).set({
+        userId: TEST_OWNER_UID,
+        basicInfo: { name: 'Legacy' },
+        metadata: { status: 'active' },
+      });
+    });
+    await assertSucceeds(
+      ownerDb().doc(`stores/${TEST_STORE_ID}/products/p1`).set(makeProduct()),
+    );
+  });
+
+  it('reconoce al owner por metadata.ownerId (canónico actual)', async () => {
+    await seed(async (db) => {
+      // Solo metadata.ownerId, sin ownerId/userId raíz.
+      await db.doc(`stores/${TEST_STORE_ID}`).set({
+        basicInfo: { name: 'Canónico' },
+        metadata: { ownerId: TEST_OWNER_UID, status: 'active' },
+      });
+    });
+    await assertSucceeds(
+      ownerDb().doc(`stores/${TEST_STORE_ID}/products/p1`).set(makeProduct()),
+    );
+  });
+
+  it('no da acceso cruzado: un owner de otra tienda no puede escribir en esta', async () => {
+    await seed(async (db) => {
+      await db
+        .doc(`stores/${OTHER_STORE_ID}`)
+        .set(makeStore({ ownerId: INTRUDER_UID }));
+    });
+    // INTRUDER es owner de OTHER_STORE_ID pero intenta escribir en TEST_STORE_ID.
+    await assertFails(
+      intruderDb()
+        .doc(`stores/${TEST_STORE_ID}/products/p1`)
+        .set(makeProduct()),
+    );
+  });
+});
+
+// =============================================================================
+// products / categories / tags — read público, escritura owner + data válida
+// =============================================================================
+
+describe.each([
+  {
+    col: 'products',
+    valid: () => makeProduct(),
+    factoryName: 'makeProduct',
+  },
+  {
+    col: 'categories',
+    valid: () => makeCategory(),
+    factoryName: 'makeCategory',
+  },
+  {
+    col: 'tags',
+    valid: () => ({ name: 'Oferta', storeId: TEST_STORE_ID }),
+    factoryName: 'tag',
+  },
+])('$col', ({ col, valid }) => {
+  const docPath = `stores/${TEST_STORE_ID}/${col}/x1`;
+
+  it('permite la lectura pública a un anónimo', async () => {
+    await seed(async (db) => {
+      await db.doc(docPath).set(valid());
+    });
+    await assertSucceeds(anonDb().doc(docPath).get());
+  });
+
+  it('permite al owner crear con data válida', async () => {
+    await assertSucceeds(ownerDb().doc(docPath).set(valid()));
+  });
+
+  it('permite al owner actualizar con data válida', async () => {
+    await seed(async (db) => {
+      await db.doc(docPath).set(valid());
+    });
+    await assertSucceeds(ownerDb().doc(docPath).set(valid()));
+  });
+
+  it('permite al owner borrar', async () => {
+    await seed(async (db) => {
+      await db.doc(docPath).set(valid());
+    });
+    await assertSucceeds(ownerDb().doc(docPath).delete());
+  });
+
+  it('rechaza que un no-owner cree', async () => {
+    await assertFails(intruderDb().doc(docPath).set(valid()));
+  });
+
+  it('rechaza que un no-owner borre', async () => {
+    await seed(async (db) => {
+      await db.doc(docPath).set(valid());
+    });
+    await assertFails(intruderDb().doc(docPath).delete());
+  });
+
+  it('rechaza crear sin el campo name (data inválida)', async () => {
+    const { name, ...sinName } = valid() as Record<string, unknown>;
+    void name;
+    await assertFails(ownerDb().doc(docPath).set(sinName));
+  });
+
+  it('rechaza crear con name vacío (data inválida)', async () => {
+    await assertFails(ownerDb().doc(docPath).set({ ...valid(), name: '' }));
+  });
+
+  it('rechaza crear sin storeId (data inválida)', async () => {
+    const { storeId, ...sinStore } = valid() as Record<string, unknown>;
+    void storeId;
+    await assertFails(ownerDb().doc(docPath).set(sinStore));
+  });
+});
+
+// Reglas específicas de products: price requerido, numérico y no-negativo.
+describe('products — validación de price', () => {
+  const docPath = `stores/${TEST_STORE_ID}/products/x1`;
+
+  it('rechaza crear sin price', async () => {
+    const { price, ...sinPrice } = makeProduct() as Record<string, unknown>;
+    void price;
+    await assertFails(ownerDb().doc(docPath).set(sinPrice));
+  });
+
+  it('rechaza crear con price negativo', async () => {
+    await assertFails(ownerDb().doc(docPath).set(makeProduct({ price: -1 })));
+  });
+
+  it('rechaza crear con price no numérico', async () => {
+    await assertFails(
+      ownerDb().doc(docPath).set(makeProduct({ price: '1000' })),
+    );
+  });
+
+  it('permite crear con price 0 (borde válido)', async () => {
+    await assertSucceeds(ownerDb().doc(docPath).set(makeProduct({ price: 0 })));
+  });
+});
+
+// =============================================================================
+// sells — create público (checkout), lectura/escritura solo owner
+// =============================================================================
+
+describe('sells/{sellId}', () => {
+  const docPath = `stores/${TEST_STORE_ID}/sells/s1`;
+
+  it('permite a un anónimo crear una venta válida con storeId coincidente', async () => {
+    await assertSucceeds(anonDb().doc(docPath).set(makeValidSell()));
+  });
+
+  it('rechaza crear una venta con items vacío', async () => {
+    await assertFails(anonDb().doc(docPath).set(makeValidSell({ items: [] })));
+  });
+
+  it('rechaza crear una venta con total negativo', async () => {
+    await assertFails(
+      anonDb()
+        .doc(docPath)
+        .set(
+          makeValidSell({
+            totals: { subtotal: 0, discount: 0, deliveryFee: 0, total: -1 },
+          }),
+        ),
+    );
+  });
+
+  it('rechaza crear una venta con storeId ajeno (tienda A apunta a B)', async () => {
+    await assertFails(
+      anonDb().doc(docPath).set(makeValidSell({ storeId: OTHER_STORE_ID })),
+    );
+  });
+
+  it('rechaza crear una venta sin una key requerida (metadata)', async () => {
+    const { metadata, ...sinMetadata } = makeValidSell() as Record<
+      string,
+      unknown
+    >;
+    void metadata;
+    await assertFails(anonDb().doc(docPath).set(sinMetadata));
+  });
+
+  it('rechaza crear una venta con customer.name vacío', async () => {
+    await assertFails(
+      anonDb()
+        .doc(docPath)
+        .set(makeValidSell({ customer: { name: '', phone: '+549110000' } })),
+    );
+  });
+
+  // SEC-01: la ruta pública (anónima) impone topes de tamaño para evitar abuso.
+  it('rechaza crear una venta con un array de items excesivo (SEC-01)', async () => {
+    const items = Array.from({ length: 101 }, (_, i) => ({
+      id: `item-${i}`,
+      productName: 'x',
+      quantity: 1,
+      unitPrice: 1,
+      subtotal: 1,
+    }));
+    await assertFails(anonDb().doc(docPath).set(makeValidSell({ items })));
+  });
+
+  it('rechaza crear una venta con customer.name desmesuradamente largo (SEC-01)', async () => {
+    await assertFails(
+      anonDb()
+        .doc(docPath)
+        .set(
+          makeValidSell({
+            customer: { name: 'a'.repeat(201), phone: '+549110000' },
+          }),
+        ),
+    );
+  });
+
+  it('permite 100 items (borde superior válido, SEC-01)', async () => {
+    const items = Array.from({ length: 100 }, (_, i) => ({
+      id: `item-${i}`,
+      productName: 'x',
+      quantity: 1,
+      unitPrice: 1,
+      subtotal: 1,
+    }));
+    await assertSucceeds(anonDb().doc(docPath).set(makeValidSell({ items })));
+  });
+
+  it('permite al owner leer las ventas de su tienda', async () => {
+    await seed(async (db) => {
+      await db.doc(docPath).set(makeValidSell());
+    });
+    await assertSucceeds(ownerDb().doc(docPath).get());
+  });
+
+  it('rechaza que un anónimo lea una venta', async () => {
+    await seed(async (db) => {
+      await db.doc(docPath).set(makeValidSell());
+    });
+    await assertFails(anonDb().doc(docPath).get());
+  });
+
+  it('rechaza que un no-owner lea una venta', async () => {
+    await seed(async (db) => {
+      await db.doc(docPath).set(makeValidSell());
+    });
+    await assertFails(intruderDb().doc(docPath).get());
+  });
+
+  it('permite al owner actualizar y borrar una venta', async () => {
+    await seed(async (db) => {
+      await db.doc(docPath).set(makeValidSell());
+    });
+    await assertSucceeds(ownerDb().doc(docPath).update({ 'metadata.note': 'x' }));
+    await assertSucceeds(ownerDb().doc(docPath).delete());
+  });
+
+  it('rechaza que un anónimo actualice o borre una venta', async () => {
+    await seed(async (db) => {
+      await db.doc(docPath).set(makeValidSell());
+    });
+    await assertFails(anonDb().doc(docPath).update({ x: 1 }));
+    await assertFails(anonDb().doc(docPath).delete());
+  });
+});
+
+// =============================================================================
+// settings — solo owner
+// =============================================================================
+
+describe('settings/{settingId}', () => {
+  const docPath = `stores/${TEST_STORE_ID}/settings/general`;
+
+  it('permite al owner leer y escribir settings', async () => {
+    await assertSucceeds(ownerDb().doc(docPath).set({ theme: 'dark' }));
+    await assertSucceeds(ownerDb().doc(docPath).get());
+  });
+
+  it('rechaza que un anónimo lea o escriba settings', async () => {
+    await assertFails(anonDb().doc(docPath).get());
+    await assertFails(anonDb().doc(docPath).set({ theme: 'dark' }));
+  });
+
+  it('rechaza que un no-owner lea o escriba settings', async () => {
+    await assertFails(intruderDb().doc(docPath).get());
+    await assertFails(intruderDb().doc(docPath).set({ theme: 'dark' }));
+  });
+});
+
+// =============================================================================
+// notifications — read/update owner; create/delete nadie (solo Admin SDK)
+// =============================================================================
+
+describe('notifications/{notificationId}', () => {
+  const docPath = `stores/${TEST_STORE_ID}/notifications/n1`;
+
+  it('permite al owner leer y actualizar notificaciones', async () => {
+    await seed(async (db) => {
+      await db.doc(docPath).set({ read: false, message: 'hola' });
+    });
+    await assertSucceeds(ownerDb().doc(docPath).get());
+    await assertSucceeds(ownerDb().doc(docPath).update({ read: true }));
+  });
+
+  it('rechaza que el owner cree una notificación (solo Admin SDK)', async () => {
+    await assertFails(ownerDb().doc(docPath).set({ read: false }));
+  });
+
+  it('rechaza que el owner borre una notificación (solo Admin SDK)', async () => {
+    await seed(async (db) => {
+      await db.doc(docPath).set({ read: false });
+    });
+    await assertFails(ownerDb().doc(docPath).delete());
+  });
+
+  it('rechaza que un no-owner lea notificaciones', async () => {
+    await seed(async (db) => {
+      await db.doc(docPath).set({ read: false });
+    });
+    await assertFails(intruderDb().doc(docPath).get());
+  });
+});
+
+// =============================================================================
+// users/{uid} — solo el propio uid
+// =============================================================================
+
+describe('users/{userId}', () => {
+  it('permite al usuario leer y escribir su propio documento', async () => {
+    await assertSucceeds(
+      ownerDb().doc(`users/${TEST_OWNER_UID}`).set({ displayName: 'Yo' }),
+    );
+    await assertSucceeds(ownerDb().doc(`users/${TEST_OWNER_UID}`).get());
+  });
+
+  it('rechaza que un usuario lea el documento de otro uid', async () => {
+    await seed(async (db) => {
+      await db.doc(`users/${TEST_OWNER_UID}`).set({ displayName: 'Yo' });
+    });
+    await assertFails(intruderDb().doc(`users/${TEST_OWNER_UID}`).get());
+  });
+
+  it('rechaza que un usuario escriba el documento de otro uid', async () => {
+    await assertFails(
+      intruderDb().doc(`users/${TEST_OWNER_UID}`).set({ displayName: 'hack' }),
+    );
+  });
+
+  it('rechaza el acceso anónimo a cualquier documento de usuario', async () => {
+    await assertFails(anonDb().doc(`users/${TEST_OWNER_UID}`).get());
+  });
+});
+
+// =============================================================================
+// Catch-all — denegar todo lo no especificado
+// =============================================================================
+
+describe('catch-all', () => {
+  it('rechaza la lectura de una colección no contemplada', async () => {
+    await assertFails(ownerDb().doc('coleccion-random/doc1').get());
+  });
+
+  it('rechaza la escritura en una colección no contemplada', async () => {
+    await assertFails(ownerDb().doc('coleccion-random/doc1').set({ x: 1 }));
+  });
+});

--- a/test/rules/storage.rules.test.ts
+++ b/test/rules/storage.rules.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests de reglas de seguridad de Storage (Fase 3).
+ *
+ * Evalúa `storage.rules` con `@firebase/rules-unit-testing` contra el emulador.
+ * Cada `allow` tiene su espejo `deny` (criterio de aceptación F).
+ *
+ * `isStoreOwner` en Storage consulta el doc `/stores/{id}` en Firestore, así que
+ * el setup siembra ese doc con reglas deshabilitadas antes de cada test.
+ *
+ * Guía: docs/test/30-rules-audit-guide.md
+ */
+import { assertFails, assertSucceeds } from '@firebase/rules-unit-testing';
+import type { RulesTestEnvironment } from '@firebase/rules-unit-testing';
+import {
+  deleteObject,
+  getBytes,
+  ref,
+  uploadBytes,
+} from 'firebase/storage';
+import { afterAll, beforeAll, beforeEach, describe, it } from 'vitest';
+
+import {
+  cleanupRulesTestEnv,
+  getRulesTestEnv,
+} from '../helpers/firebase-emulator';
+import { makeStore, TEST_OWNER_UID, TEST_STORE_ID } from '../helpers/factories';
+
+const INTRUDER_UID = 'intruso-uid';
+
+/** Bytes mínimos con cabecera PNG; el rule solo mira contentType y tamaño. */
+const IMG_BYTES = new Uint8Array([0x89, 0x50, 0x4e, 0x47]);
+const IMG_META = { contentType: 'image/png' } as const;
+/** Archivo > 5 MB para ejercitar el tope de tamaño. */
+const BIG_BYTES = new Uint8Array(5 * 1024 * 1024 + 1);
+
+let env: RulesTestEnvironment;
+
+const ownerStorage = () => env.authenticatedContext(TEST_OWNER_UID).storage();
+const intruderStorage = () => env.authenticatedContext(INTRUDER_UID).storage();
+const anonStorage = () => env.unauthenticatedContext().storage();
+
+async function seedObject(path: string) {
+  await env.withSecurityRulesDisabled(async (ctx) => {
+    await uploadBytes(ref(ctx.storage(), path), IMG_BYTES, IMG_META);
+  });
+}
+
+beforeAll(async () => {
+  env = await getRulesTestEnv();
+});
+
+afterAll(async () => {
+  await cleanupRulesTestEnv();
+});
+
+beforeEach(async () => {
+  await env.clearStorage();
+  await env.clearFirestore();
+  // isStoreOwner (storage.rules) lee /stores/{id} de Firestore.
+  await env.withSecurityRulesDisabled(async (ctx) => {
+    await (ctx.firestore() as unknown as FirebaseFirestore.Firestore)
+      .doc(`stores/${TEST_STORE_ID}`)
+      .set(makeStore());
+  });
+});
+
+// =============================================================================
+// stores/{id}/** — read público, write/delete solo owner + imagen válida
+// =============================================================================
+
+describe('stores/{storeId}/**', () => {
+  const path = `stores/${TEST_STORE_ID}/products/foto.png`;
+
+  it('permite la lectura pública de una imagen de tienda', async () => {
+    await seedObject(path);
+    await assertSucceeds(getBytes(ref(anonStorage(), path)));
+  });
+
+  it('permite al owner subir una imagen válida', async () => {
+    await assertSucceeds(
+      uploadBytes(ref(ownerStorage(), path), IMG_BYTES, IMG_META),
+    );
+  });
+
+  it('permite al owner borrar una imagen', async () => {
+    await seedObject(path);
+    await assertSucceeds(deleteObject(ref(ownerStorage(), path)));
+  });
+
+  it('rechaza que un no-owner suba una imagen', async () => {
+    await assertFails(
+      uploadBytes(ref(intruderStorage(), path), IMG_BYTES, IMG_META),
+    );
+  });
+
+  it('rechaza que un no-owner borre una imagen', async () => {
+    await seedObject(path);
+    await assertFails(deleteObject(ref(intruderStorage(), path)));
+  });
+
+  it('rechaza subir un archivo de más de 5 MB', async () => {
+    await assertFails(
+      uploadBytes(ref(ownerStorage(), path), BIG_BYTES, IMG_META),
+    );
+  });
+
+  it('rechaza subir un archivo que no es imagen (application/pdf)', async () => {
+    await assertFails(
+      uploadBytes(ref(ownerStorage(), path), IMG_BYTES, {
+        contentType: 'application/pdf',
+      }),
+    );
+  });
+});
+
+// =============================================================================
+// users/{uid}/avatar/** — solo el propio uid + imagen válida
+// =============================================================================
+
+describe('users/{userId}/avatar/**', () => {
+  const path = `users/${TEST_OWNER_UID}/avatar/me.png`;
+
+  it('permite al propio usuario subir su avatar (imagen válida)', async () => {
+    await assertSucceeds(
+      uploadBytes(ref(ownerStorage(), path), IMG_BYTES, IMG_META),
+    );
+  });
+
+  it('rechaza que otro usuario suba el avatar ajeno', async () => {
+    await assertFails(
+      uploadBytes(ref(intruderStorage(), path), IMG_BYTES, IMG_META),
+    );
+  });
+
+  it('rechaza subir un avatar que no es imagen', async () => {
+    await assertFails(
+      uploadBytes(ref(ownerStorage(), path), IMG_BYTES, {
+        contentType: 'application/pdf',
+      }),
+    );
+  });
+
+  it('rechaza el acceso anónimo al avatar', async () => {
+    await assertFails(
+      uploadBytes(ref(anonStorage(), path), IMG_BYTES, IMG_META),
+    );
+  });
+});
+
+// =============================================================================
+// temp/{uid}/** — archivos temporales del propio usuario
+// =============================================================================
+
+describe('temp/{userId}/**', () => {
+  const path = `temp/${TEST_OWNER_UID}/upload.png`;
+
+  it('permite al propio usuario subir un archivo temporal (imagen)', async () => {
+    await assertSucceeds(
+      uploadBytes(ref(ownerStorage(), path), IMG_BYTES, IMG_META),
+    );
+  });
+
+  it('rechaza que otro usuario suba en la carpeta temporal ajena', async () => {
+    await assertFails(
+      uploadBytes(ref(intruderStorage(), path), IMG_BYTES, IMG_META),
+    );
+  });
+});
+
+// =============================================================================
+// Catch-all — denegar cualquier otra ruta
+// =============================================================================
+
+describe('catch-all', () => {
+  it('rechaza subir a una ruta no contemplada', async () => {
+    await assertFails(
+      uploadBytes(ref(ownerStorage(), 'random/file.png'), IMG_BYTES, IMG_META),
+    );
+  });
+
+  it('rechaza leer una ruta no contemplada', async () => {
+    await assertFails(getBytes(ref(anonStorage(), 'random/file.png')));
+  });
+});

--- a/test/rules/storage.rules.test.ts
+++ b/test/rules/storage.rules.test.ts
@@ -179,6 +179,9 @@ describe('catch-all', () => {
   });
 
   it('rechaza leer una ruta no contemplada', async () => {
+    // Sembramos el objeto (saltándose las reglas) para que el fallo sea por
+    // denegación del catch-all y no por "objeto inexistente" (404).
+    await seedObject('random/file.png');
     await assertFails(getBytes(ref(anonStorage(), 'random/file.png')));
   });
 });


### PR DESCRIPTION
## Fase 3 — Auditoría de reglas Firestore/Storage

Cierra la **Fase 3** del [roadmap de testing](docs/test/README.md): suite de reglas de seguridad con `@firebase/rules-unit-testing` + auditoría con la skill `firebase-security-rules-auditor`.

### Qué incluye
- **`test/rules/firestore.rules.test.ts`** — matriz allow/deny completa: `stores`, `products`/`categories`/`tags`, `sells`, `settings`, `notifications`, `users`, catch-all. Cada `allow` con su espejo `deny` (criterio F). Incluye el edge de ownership por los **3 campos legacy** (`ownerId`/`userId`/`metadata.ownerId`) sin acceso cruzado entre tiendas.
- **`test/rules/storage.rules.test.ts`** — `stores/**` (read público; owner + imagen <5MB en write/delete), `users/{uid}/avatar`, `temp/{uid}`, catch-all (deny por no-imagen, >5MB, no-owner).
- **81 tests verdes**, deterministas (3 corridas seguidas), aislados (`clearFirestore`/`clearStorage`), solo proyecto `demo-*`.

### Auditoría (skill, 3/5)
Informe completo en [`docs/test/60-firebase-security-audit.md`](docs/test/60-firebase-security-audit.md); hallazgos en [`docs/hallazgos/testing-fase3-2026-06-19.md`](docs/hallazgos/testing-fase3-2026-06-19.md).

| ID | Sev. | Estado |
|----|------|--------|
| **SEC-01** | Alta | ✅ **Corregido** — `sells.create` (única escritura pública sin auth) no acotaba tamaños. `isValidSellData()` ahora limita `items.size()<=100`, `customer.name.size()<=200` y exige `storeId is string`. La ruta legítima usa Admin SDK (bypasea reglas) → no afecta el checkout real. Con regresión. |
| SEC-02 | Media | 📄 Documentado — `update` no fija `storeId` al path |
| SEC-03 | Baja | 📄 Documentado — `isStoreOwner` accede directo a `metadata.ownerId` (vs `.get()` seguro en storage). Tests confirman que **no es bug funcional** |
| SEC-04 | Media | 📄 Documentado — roles `admin`/`employee` sin reglas |
| SEC-05 | Baja | 📄 Documentado — `users/{uid}` sin validación de campos |

**Sin fugas de datos ni escalación de privilegios.**

### Índices
Sin gaps para las queries del repo. Sobre-aprovisionamiento menor en `sells` (filtros movidos a memoria, `sale.service.ts:131`). Caveat: el emulador no enforce índices compuestos (revisión estática).

### CI
El job `emulators` ahora corre **integración + reglas** (`test:int && test:rules`).

### Verificación
- `npm run test:emu` → integración (105) + reglas (81) verdes.
- `npm run test:rules` ×3 → determinista.
- `npm run typecheck` y `npm run lint` limpios.
- Unit suite intacta (386).

🤖 Generated with [Claude Code](https://claude.com/claude-code)