### PR TITLE
fix(hallazgos): cierra los 5 hallazgos Alta/Media abiertos de testing

### DIFF
--- a/docs/hallazgos/testing-fase1-2026-06-15.md
+++ b/docs/hallazgos/testing-fase1-2026-06-15.md
@@ -36,7 +36,12 @@ debería poder renderizarse sin esas props.
 
 ---
 
-## H-2 (Media) — El `<form>` sin `noValidate` oculta los mensajes de validación de Zod
+## H-2 (Media) — ✅ RESUELTO — El `<form>` sin `noValidate` oculta los mensajes de validación de Zod
+
+> **Estado (2026-06-24):** corregido. Se agregó `noValidate` a los `<form>` de
+> `LoginForm`, `RegisterForm` y `UserRegistrationStep`, de modo que los mensajes de
+> Zod (en español) se muestran de forma consistente. Regresión:
+> `LoginForm.test.tsx` → "muestra el mensaje de Zod cuando el formato de email es inválido".
 
 **Archivos:** `src/features/auth/components/LoginForm.tsx` (y todo form con
 `<input type="email">` cuyo `<form>` no use `noValidate`).

--- a/docs/hallazgos/testing-fase3-2026-06-19.md
+++ b/docs/hallazgos/testing-fase3-2026-06-19.md
@@ -49,7 +49,13 @@ request.resource.data.customer.name.size() <= 200
 
 ---
 
-## SEC-02 (Media) — 📄 documentado — `update` no fija `storeId` al path
+## SEC-02 (Media) — ✅ RESUELTO — `update` no fija `storeId` al path
+
+> **Estado (2026-06-24):** corregido. Se agregó `request.resource.data.storeId ==
+> storeId` a `create` y `update` de `products` en `firestore.rules` (mismo criterio
+> que `sells.create`). Regresión: `test/rules/firestore.rules.test.ts` → bloque
+> "products — storeId fijado al path (SEC-02)" (allow con storeId coincidente, deny
+> con storeId ajeno en create y update).
 
 **Archivo:** `firestore.rules` (`products`/`sells` `update`)
 
@@ -60,9 +66,6 @@ tienda. No hay fuga cross-store (solo escribe en su path), pero corrompe la
 integridad referencial del campo.
 
 **Impacto:** bajo/medio, acotado a la propia tienda del owner.
-
-**Recomendación (no aplicada):** agregar `request.resource.data.storeId == storeId`
-a `create`/`update` de `products` (hoy solo lo hace `sells.create`).
 
 ---
 

--- a/docs/hallazgos/testing-fase4-2026-06-22.md
+++ b/docs/hallazgos/testing-fase4-2026-06-22.md
@@ -59,7 +59,7 @@ flujo de compra.
 
 ---
 
-## E2E-03 (Media) — ✅ RESUELTO (parcial) — Settings: varios "Guardar cambios" sin selector estable
+## E2E-03 (Media) — ✅ RESUELTO — Settings: varios "Guardar cambios" sin selector estable
 
 **Archivos:**
 - `src/features/dashboard/modules/store-settings/components/sections/BasicInfoSection.tsx`
@@ -76,8 +76,9 @@ si se agrega/quita una sección.
 secciones rompería el spec silenciosamente (guardaría la sección equivocada).
 
 **Corrección aplicada:** se agregó `data-testid="save-contact"` al botón de
-guardado de la sección Contacto (el que usa el spec 04). Pendiente (no bloqueante):
-`save-basic` y `save-social` para las otras dos secciones.
+guardado de la sección Contacto (el que usa el spec 04). **Completado (2026-06-24):**
+se agregaron `data-testid="save-basic"` (`BasicInfoSection`) y `data-testid="save-social"`
+(`SocialLinksSection`), eliminando la dependencia del índice de render para futuros specs.
 
 ---
 
@@ -167,7 +168,13 @@ cuenta y, a futuro, evaluar si la sesión podría sembrarse server-side para tes
 
 ---
 
-## E2E-08 (Media) — 📄 documentado — Reglas de contraseña distintas cliente vs servidor
+## E2E-08 (Media) — ✅ RESUELTO — Reglas de contraseña distintas cliente vs servidor
+
+> **Estado (2026-06-24):** corregido. Se extrajo `passwordSchema` como fuente única
+> en `register.schema.ts` y `UserRegistrationStep.tsx` ahora lo reutiliza, de modo
+> que cliente y servidor exigen lo mismo (≥8 + mayúscula + número). Se agregó además
+> el texto de requisitos en el UI. Regresión: `register.schema.test.ts` → bloque
+> "passwordSchema (contrato compartido cliente/servidor)".
 
 **Archivos:**
 - `src/features/auth/components/UserRegistrationStep.tsx` (schema cliente: `password.min(6)`)
@@ -235,12 +242,12 @@ decorativos del modal con `pointer-events-none` y revisar el z-index.
 |--------|-----------|--------|------|
 | E2E-01 | Baja | ✅ Resuelto | Nombre accesible/testid en carrito |
 | E2E-02 | Baja | 📄 Documentado | Precio del catálogo sin `formatPrice` |
-| E2E-03 | Media | ✅ Resuelto (parcial) | Testid de guardado en settings (Contacto) |
+| E2E-03 | Media | ✅ Resuelto | Testid de guardado en settings (las 3 secciones) |
 | E2E-04 | Media | ✅ Resuelto | Testid de navegación en onboarding |
 | E2E-05 | Baja | ✅ Resuelto (parcial) | Testid de precio en form de producto |
 | E2E-06 | Baja | 📄 Documentado | Checkout abre WhatsApp por popup |
 | E2E-07 | Media | 📄 Documentado | Sesión no reutilizable vía storageState |
-| E2E-08 | Media | 📄 Documentado | Reglas de contraseña cliente ≠ servidor |
+| E2E-08 | Media | ✅ Resuelto | Reglas de contraseña cliente ≠ servidor |
 | E2E-09 | Baja | 📄 Documentado | Settings: reset async borra el dirty |
 | E2E-10 | Baja | ✅ Resuelto (en test) | Modal de bienvenida se solapa con el carrito |
 

--- a/docs/hallazgos/testing-fase4-2026-06-22.md
+++ b/docs/hallazgos/testing-fase4-2026-06-22.md
@@ -236,6 +236,21 @@ decorativos del modal con `pointer-events-none` y revisar el z-index.
 
 ---
 
+## Nota de tooling (2026-06-24) — Playwright vs Node 24+
+
+Al correr `npm run test:e2e` en local con **Node 24.x**, Playwright `1.61.0` fallaba
+al **cargar** todos los specs con `TypeError: context.conditions?.includes is not a
+function`. Causa: en Node ≥24 el hook de resolución de módulos recibe
+`context.conditions` como `Set` (en Node 22, lo que usa CI, es un array), y la
+versión `1.61.0` invocaba `.includes()` sobre él. No era un problema de los specs ni
+de la app.
+
+**Resuelto:** se elevó el piso a `@playwright/test@^1.61.1`, que cambió a
+`new Set(context.conditions).has(...)` (compatible con array y `Set`). La suite
+completa (9 tests, 5 archivos) corre verde tanto en Node 22 (CI) como en Node 24+.
+
+---
+
 ## Resumen
 
 | Código | Severidad | Estado | Tema |

--- a/docs/hallazgos/validacion-forms-y-import-2026-06-13.md
+++ b/docs/hallazgos/validacion-forms-y-import-2026-06-13.md
@@ -9,7 +9,13 @@ generación de tests, más allá del fix puntual del import.
 
 ---
 
-## H-1 (Alta) — Doble-submit en importación de productos por Excel
+## H-1 (Alta) — ✅ RESUELTO — Doble-submit en importación de productos por Excel
+
+> **Estado (2026-06-24):** corregido. El botón "Importar" del paso `preview` ahora
+> incluye `isPending` en su `disabled` y `proceedToImport()` tiene guard sincrónico
+> `if (isPending) return`. El tope total del servidor queda como backstop ante un
+> doble-tap que esquive la UI. Regresión: `test/integration/products.int.test.ts`
+> → "el tope total backstopea un doble-submit (no excede MAX_IMPORT_PRODUCTS)".
 
 **Archivos:**
 - `src/features/products/components/product-import-dialog.tsx`

--- a/firestore.rules
+++ b/firestore.rules
@@ -89,8 +89,13 @@ service cloud.firestore {
       match /products/{productId} {
         // Lectura pública (catálogo sin autenticación)
         allow read: if true;
-        allow create: if isStoreOwner(storeId) && isValidProductData();
-        allow update: if isStoreOwner(storeId) && isValidProductData();
+        // Se fija storeId del documento al storeId de la ruta (SEC-02) para que el
+        // owner no pueda escribir un storeId ajeno dentro de un producto de su
+        // propia tienda (integridad referencial; mismo criterio que sells.create).
+        allow create: if isStoreOwner(storeId) && isValidProductData() &&
+                         request.resource.data.storeId == storeId;
+        allow update: if isStoreOwner(storeId) && isValidProductData() &&
+                         request.resource.data.storeId == storeId;
         allow delete: if isStoreOwner(storeId);
       }
 

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
   },
   "devDependencies": {
     "@firebase/rules-unit-testing": "^5.0.1",
-    "@playwright/test": "^1.60.0",
+    "@playwright/test": "^1.61.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/src/features/auth/components/LoginForm.test.tsx
+++ b/src/features/auth/components/LoginForm.test.tsx
@@ -34,8 +34,6 @@ describe('LoginForm', () => {
   });
 
   it('muestra error cuando el email está vacío', async () => {
-    // El formato de email lo bloquea la validación nativa del navegador (type="email"),
-    // por eso aquí se prueba el caso requerido, que sí llega al resolver de Zod.
     const user = userEvent.setup();
     render(<LoginForm />);
 
@@ -43,6 +41,20 @@ describe('LoginForm', () => {
     await user.click(screen.getByRole('button', { name: 'Iniciar sesión' }));
 
     expect(await screen.findByText('Email es requerido')).toBeInTheDocument();
+    expect(hybridLogin).not.toHaveBeenCalled();
+  });
+
+  it('muestra el mensaje de Zod cuando el formato de email es inválido', async () => {
+    // Con `noValidate` en el <form> (hallazgo Fase1 H-2), la validación nativa del
+    // navegador ya no intercepta el submit y el mensaje custom de Zod sí se muestra.
+    const user = userEvent.setup();
+    render(<LoginForm />);
+
+    await user.type(screen.getByLabelText('Email'), 'no-es-un-email');
+    await user.type(screen.getByLabelText(/contraseña/i), 'secreto123');
+    await user.click(screen.getByRole('button', { name: 'Iniciar sesión' }));
+
+    expect(await screen.findByText('Formato de email inválido')).toBeInTheDocument();
     expect(hybridLogin).not.toHaveBeenCalled();
   });
 

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -90,7 +90,7 @@ export const LoginForm = () => {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
           <div className="space-y-2">
             <Label htmlFor="email">Email</Label>
             <Input

--- a/src/features/auth/components/RegisterForm.tsx
+++ b/src/features/auth/components/RegisterForm.tsx
@@ -109,7 +109,7 @@ export const RegisterForm = () => {
       </CardHeader>
 
       <CardContent>
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
           {/* Datos personales */}
           <div className="space-y-2">
             <Label htmlFor="email">Email</Label>

--- a/src/features/auth/components/UserRegistrationStep.tsx
+++ b/src/features/auth/components/UserRegistrationStep.tsx
@@ -19,14 +19,19 @@ import { Label } from '@/components/ui/label';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { GoogleButton } from '@/features/auth/components/GoogleButton';
+import { passwordSchema, displayNameSchema } from '@/features/auth/schemas/register.schema';
 import { UserData } from './MultiStepRegister';
 
-// Schema de validación para el primer paso
+// Schema de validación para el primer paso.
+// La contraseña y el nombre reutilizan los schemas compartidos (fuente única)
+// para no divergir de la validación del servidor en `registerAction`: un nombre
+// de 2 chars o una contraseña débil pasaban el cliente y fallaban en silencio en
+// el servidor (hallazgo E2E-08).
 const userRegistrationSchema = z.object({
   email: z.string().email('Email inválido'),
-  password: z.string().min(6, 'La contraseña debe tener al menos 6 caracteres'),
+  password: passwordSchema,
   confirmPassword: z.string(),
-  displayName: z.string().min(2, 'El nombre debe tener al menos 2 caracteres'),
+  displayName: displayNameSchema,
   terms: z.boolean().refine(val => val === true, {
     message: 'Debes aceptar los términos y condiciones'
   })
@@ -125,7 +130,7 @@ export const UserRegistrationStep: React.FC<UserRegistrationStepProps> = ({
           </div>
         </div>
 
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4" noValidate>
           {/* Email */}
           <div className="space-y-2">
             <Label htmlFor="email" className="flex items-center gap-2">
@@ -194,8 +199,12 @@ export const UserRegistrationStep: React.FC<UserRegistrationStepProps> = ({
                 )}
               </Button>
             </div>
-            {errors.password && (
+            {errors.password ? (
               <p className="text-sm text-red-500">{errors.password.message}</p>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Mínimo 8 caracteres, con al menos una mayúscula y un número.
+              </p>
             )}
           </div>
 

--- a/src/features/auth/schemas/register.schema.test.ts
+++ b/src/features/auth/schemas/register.schema.test.ts
@@ -5,7 +5,7 @@
  */
 import { describe, expect, it } from 'vitest';
 import { issueFor } from '../../../../test/helpers/zod';
-import { registerSchema, registerServerSchema } from './register.schema';
+import { passwordSchema, registerSchema, registerServerSchema } from './register.schema';
 
 const valid = {
   email: 'user@example.com',
@@ -77,6 +77,21 @@ describe('registerSchema', () => {
     it('rechaza más de 50 caracteres', () => {
       const r = registerSchema.safeParse({ ...valid, displayName: 'a'.repeat(51) });
       expect(issueFor(r, 'displayName')).toBe('El nombre no puede exceder 50 caracteres');
+    });
+  });
+
+  // passwordSchema es la fuente única compartida entre el form cliente
+  // (UserRegistrationStep) y el servidor (registerAction). Lockear su política
+  // acá garantiza que el cliente no acepte contraseñas que el servidor rechaza
+  // (hallazgo E2E-08).
+  describe('passwordSchema (contrato compartido cliente/servidor)', () => {
+    it('rechaza la contraseña débil "123456" que el cliente aceptaba antes', () => {
+      const r = passwordSchema.safeParse('123456');
+      expect(r.success).toBe(false);
+    });
+
+    it('acepta una contraseña que cumple la política OWASP', () => {
+      expect(passwordSchema.safeParse('Abcdefg1').success).toBe(true);
     });
   });
 

--- a/src/features/auth/schemas/register.schema.ts
+++ b/src/features/auth/schemas/register.schema.ts
@@ -17,6 +17,36 @@ import { z } from 'zod';
 // SCHEMA
 // ============================================================================
 
+/**
+ * Schema de contraseña — fuente única compartida entre cliente y servidor.
+ * Reutilizar en cualquier form de registro/cambio de contraseña para evitar
+ * divergencias (ver hallazgo E2E-08: el cliente exigía menos que el servidor
+ * y el registro fallaba en silencio).
+ */
+export const passwordSchema = z
+    .string({ required_error: 'Contraseña es requerida' })
+    .min(8, 'La contraseña debe tener al menos 8 caracteres')
+    .max(100, 'La contraseña no puede exceder 100 caracteres')
+    .regex(
+        /[A-Z]/,
+        'La contraseña debe contener al menos una letra mayúscula'
+    )
+    .regex(
+        /[0-9]/,
+        'La contraseña debe contener al menos un número'
+    );
+
+/**
+ * Schema de nombre visible — fuente única compartida entre cliente y servidor.
+ * Igual que `passwordSchema`, evita que el form cliente acepte un nombre que el
+ * servidor luego rechaza en silencio (misma clase de bug que E2E-08).
+ */
+export const displayNameSchema = z
+    .string({ required_error: 'Nombre es requerido' })
+    .min(3, 'El nombre debe tener al menos 3 caracteres')
+    .max(50, 'El nombre no puede exceder 50 caracteres')
+    .trim();
+
 export const registerBaseSchema = z.object({
     email: z
         .string({ required_error: 'Email es requerido' })
@@ -25,27 +55,12 @@ export const registerBaseSchema = z.object({
         .toLowerCase()
         .trim(),
 
-    password: z
-        .string({ required_error: 'Contraseña es requerida' })
-        .min(8, 'La contraseña debe tener al menos 8 caracteres')
-        .max(100, 'La contraseña no puede exceder 100 caracteres')
-        .regex(
-            /[A-Z]/,
-            'La contraseña debe contener al menos una letra mayúscula'
-        )
-        .regex(
-            /[0-9]/,
-            'La contraseña debe contener al menos un número'
-        ),
+    password: passwordSchema,
 
     confirmPassword: z
         .string({ required_error: 'Confirma tu contraseña' }),
 
-    displayName: z
-        .string({ required_error: 'Nombre es requerido' })
-        .min(3, 'El nombre debe tener al menos 3 caracteres')
-        .max(50, 'El nombre no puede exceder 50 caracteres')
-        .trim(),
+    displayName: displayNameSchema,
 });
 
 export const registerSchema = registerBaseSchema.refine(

--- a/src/features/dashboard/modules/store-settings/components/sections/BasicInfoSection.tsx
+++ b/src/features/dashboard/modules/store-settings/components/sections/BasicInfoSection.tsx
@@ -479,6 +479,7 @@ Ante cualquier consulta, estamos a disposición. 😊`;
         <Button
           onClick={handleSectionSave}
           disabled={isBasicSaving || !formState.isDirty}
+          data-testid="save-basic"
           className="flex items-center justify-center gap-2 w-full sm:w-auto min-w-[160px] bg-indigo-600 hover:bg-indigo-700"
         >
           {isBasicSaving ? (

--- a/src/features/dashboard/modules/store-settings/components/sections/SocialLinksSection.tsx
+++ b/src/features/dashboard/modules/store-settings/components/sections/SocialLinksSection.tsx
@@ -318,6 +318,7 @@ export function SocialLinksSection({
         <Button
           onClick={handleSectionSave}
           disabled={isCurrentlySaving || !formState.isDirty}
+          data-testid="save-social"
           className="flex items-center justify-center gap-2 w-full sm:w-auto min-w-[160px] bg-indigo-600 hover:bg-indigo-700"
         >
           {isCurrentlySaving ? (

--- a/src/features/products/components/product-import-dialog.tsx
+++ b/src/features/products/components/product-import-dialog.tsx
@@ -127,6 +127,10 @@ export default function ProductImportDialog({ onClose, onSuccess, currentProduct
     }
 
     function proceedToImport() {
+        // Guard anti doble-submit: si ya hay un import en curso, ignorar clicks
+        // adicionales (doble-click / doble-tap). importProductsAction no es
+        // idempotente, así que dos invocaciones duplicarían el lote.
+        if (isPending) return;
         if (validRows.length === 0) return;
 
         if (validRows.length > availableSlots) {
@@ -421,7 +425,7 @@ export default function ProductImportDialog({ onClose, onSuccess, currentProduct
                             </button>
                             <button
                                 onClick={handleImportClick}
-                                disabled={validRows.length === 0 || validRows.length > availableSlots}
+                                disabled={validRows.length === 0 || validRows.length > availableSlots || isPending}
                                 className="px-6 py-2 text-sm font-bold text-white bg-blue-600 rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
                             >
                                 Importar {validRows.length} producto{validRows.length !== 1 ? 's' : ''}

--- a/test/integration/products.int.test.ts
+++ b/test/integration/products.int.test.ts
@@ -29,6 +29,7 @@ import {
   deleteProductAction,
 } from '@/features/products/actions/product.actions';
 import { importProductsAction } from '@/features/products/actions/product-import.actions';
+import { MAX_IMPORT_PRODUCTS } from '@/features/products/schemas/product-import.schema';
 import type { ProductImportRow } from '@/features/products/schemas/product-import.schema';
 import type { ProductImportRowRaw } from '@/features/products/schemas/product-import.schema';
 import { adminDb, getAdminApp, clearFirestore } from '../helpers/firebase-emulator';
@@ -264,6 +265,32 @@ describe('importProductsAction', () => {
     vi.mocked(getServerSession).mockResolvedValue(null as never);
     const res = await importProductsAction([{ nombre: 'X', precio: '1', categoria: 'Cat' }]);
     expect(res.success).toBe(false);
+  });
+
+  it('el tope total backstopea un doble-submit (no excede MAX_IMPORT_PRODUCTS)', async () => {
+    // Defensa primaria del doble-submit: el guard `isPending` en el diálogo
+    // (product-import-dialog) impide la segunda invocación. Acá se verifica el
+    // BACKSTOP del servidor: si dos imports llegaran igual (p. ej. doble-tap que
+    // esquiva la UI), el re-chequeo de tope total impide superar el límite y
+    // duplicar el lote completo.
+    const half = Math.ceil(MAX_IMPORT_PRODUCTS * 0.6); // 0.6+0.6 = 1.2× → excede
+    const rawRows: ProductImportRowRaw[] = Array.from({ length: half }, (_, i) => ({
+      nombre: `Producto ${i}`,
+      precio: '100',
+      categoria: 'Importados',
+    }));
+
+    const first = await importProductsAction(rawRows);
+    expect(first.success).toBe(true);
+
+    const second = await importProductsAction(rawRows);
+    expect(second.success).toBe(false);
+    if (second.success) return;
+    expect(second.errors._form[0]).toMatch(/límite|alcanzó/);
+
+    // El segundo lote no se persistió: la colección quedó en el primer import.
+    const count = await productsCol().count().get();
+    expect(count.data().count).toBe(half);
   });
 });
 

--- a/test/rules/firestore.rules.test.ts
+++ b/test/rules/firestore.rules.test.ts
@@ -258,6 +258,32 @@ describe('products — validación de price', () => {
   });
 });
 
+// SEC-02: el storeId del documento debe coincidir con el de la ruta.
+describe('products — storeId fijado al path (SEC-02)', () => {
+  const docPath = `stores/${TEST_STORE_ID}/products/x1`;
+
+  it('permite al owner crear con storeId coincidente (allow)', async () => {
+    await assertSucceeds(
+      ownerDb().doc(docPath).set(makeProduct({ storeId: TEST_STORE_ID })),
+    );
+  });
+
+  it('rechaza crear con storeId ajeno dentro de su propia tienda (deny)', async () => {
+    await assertFails(
+      ownerDb().doc(docPath).set(makeProduct({ storeId: OTHER_STORE_ID })),
+    );
+  });
+
+  it('rechaza actualizar inyectando un storeId ajeno (deny)', async () => {
+    await seed(async (db) => {
+      await db.doc(docPath).set(makeProduct({ storeId: TEST_STORE_ID }));
+    });
+    await assertFails(
+      ownerDb().doc(docPath).set(makeProduct({ storeId: OTHER_STORE_ID })),
+    );
+  });
+});
+
 // =============================================================================
 // sells — create público (checkout), lectura/escritura solo owner
 // =============================================================================


### PR DESCRIPTION
## Contexto

Tras cerrar las 5 fases de testing, quedaban hallazgos abiertos documentados en `docs/hallazgos/`. Este PR cierra los **5 de severidad Alta/Media** (verificados en código, no solo en los docs) y refina su corrección con un code-review. Las mejoras Baja/cosmética y las decisiones conscientes (SEC-04 roles, F5-01 merge de cobertura) quedan como backlog documentado.

## Cambios

| Hallazgo | Sev. | Fix | Regresión |
|----------|------|-----|-----------|
| **E2E-08** · password cliente≠servidor | Alta | `passwordSchema` extraído como fuente única, reusado en `UserRegistrationStep` (≥8 + mayúscula + número) + requisitos en UI | `register.schema.test.ts` |
| **Doble-submit import** | Alta | `disabled={…\|\|isPending}` en botón preview + guard `if(isPending)return`; tope total como backstop server | `products.int.test.ts` |
| **Fase1 H-2** · `noValidate` | Media | agregado a Login/Register/UserRegistration → mensajes Zod en español | `LoginForm.test.tsx` |
| **SEC-02** · `storeId` no fijado al path | Media | `request.resource.data.storeId == storeId` en create/update de products | `firestore.rules.test.ts` (mirror) |
| **E2E-03** · testids de guardado | Media | `save-basic` y `save-social` en settings | spec ya usaba testid |

### Refinamiento del code-review
El review detectó que `displayName` tenía la **misma divergencia silenciosa** que password (cliente `min(2)`/sin tope vs servidor `min(3)`/`max(50)`). Se cerró extrayendo y reusando `displayNameSchema`.

### Fix de tooling E2E (Node 24+)
`npm run test:e2e` fallaba al cargar los specs en Node 24.x (`context.conditions?.includes is not a function`): en Node ≥24 el hook de resolución recibe `context.conditions` como `Set` y Playwright 1.61.0 llamaba `.includes()`. Se elevó el piso a `@playwright/test@^1.61.1` (usa `new Set(...).has(...)`, compatible con array y Set). No era un problema de los specs ni de la app — CI en Node 22 ya pasaba.

## Verificación

- ✅ `npm run lint` — sin warnings/errors
- ✅ `npm run typecheck` — limpio
- ✅ `npm run test:cov` — **453 unit** (gate de cobertura verde)
- ✅ `npm run test:emu` — **190 integración + reglas** (incluye los nuevos casos SEC-02 y backstop doble-submit)
- ✅ `npm run test:e2e` — **9 E2E (5 archivos) verdes** end-to-end contra emuladores + datos sembrados, en Node 24

## Notas para el gate de avance
Si la próxima etapa toca **roles/permisos** o **pagos**, SEC-04 (roles admin/employee sin reglas) y el hallazgo de `updateSubscriptionAction` (stripe) dejan de ser backlog y pasan a pre-requisito.

🤖 Generated with [Claude Code](https://claude.com/claude-code)