### PR TITLE
fix(ux): hallazgos de usuarios (carrito, 404 config, WhatsApp, horarios) + settings (pérdida de datos, removeChild) + CI e2e

### DIFF
--- a/docs/hallazgos/fixes-ux-usuarios-2026-06-24.md
+++ b/docs/hallazgos/fixes-ux-usuarios-2026-06-24.md
@@ -107,35 +107,71 @@ abre `/dashboard/settings/schedule`; "Ubicación" ya no muestra horarios; guarda
 
 ---
 
-## 5. ✅ CI — e2e `04-settings` inestable (WhatsApp de contacto)
+## 5. ✅ CI e2e + bug real de pérdida de datos en settings (E2E-09)
 
-**Síntoma:** el job `emulators`/`e2e` de GitHub Actions fallaba intermitente en
-`e2e/04-settings.spec.ts › edita el WhatsApp de contacto y persiste tras recargar`
-(p. ej. "1 failed, 8 passed"), incluso con `retries: 1`.
+Se cerró en dos iteraciones. La segunda corrigió tanto el CI como un **bug real de
+pérdida de datos** (no solo flakiness de test).
 
-**Causa raíz (no era un bug de la app):** tras un guardado exitoso, react-hook-form
-**rebasa** el form y `isDirty` vuelve a `false` con el nuevo número como baseline. El
-spec asertaba el **toast efímero** ("información de contacto guardada") dentro del
-`expect.toPass`. Cuando ese assert flaqueaba (el toast ya se había desvanecido), los
-reintentos reescribían el **mismo** número → al ser igual al baseline, RHF no volvía a
-marcar `isDirty` → el botón nunca se re-habilitaba → deadlock hasta el timeout de 25 s.
-Se confirmó reproduciendo en local contra emuladores: 4/5 fallos con el spec viejo.
+### 5a. `02-catalog-checkout` — locator del link de WhatsApp
+El spec buscaba el link por `/reenviar por whatsapp/i`; en la ronda 1 renombré el botón a
+**"Abrir WhatsApp"** → no lo encontraba. Fix: locator → `/abrir whatsapp/i` (spec +
+`docs/test/40-e2e-guide.md`). Verificado 4/4.
 
-**Cambios (`e2e/04-settings.spec.ts`, solo el test):**
-- Ya no se asiste sobre el toast (señal efímera).
-- Cada intento detecta primero si el número **ya quedó guardado** (objetivo cumplido) y
-  retorna; rompe el deadlock de "no puedo re-ensuciar el mismo valor".
-- La señal de guardado pasa a ser estable: el botón **se deshabilita** (guardado +
-  rebaseline de RHF).
+### 5b. `04-settings` — el WhatsApp guardaba el valor VIEJO (bug de app)
+**Causa raíz (bug real, hallazgo E2E-09):** hay varias instancias de `useProfile`
+compartiendo el store de Zustand. Un `setProfile` async (re-fetch) dispara `reset(form)`
+que **pisa la edición en curso** del usuario: en la ventana entre que el botón se habilita
+y el click se procesa, el form se revierte al valor sembrado e `isDirty` vuelve a `false`.
+`handleSectionSave` entonces lee el valor viejo y lo guarda — el toast dice "guardado
+correctamente" pero persiste el número anterior. Confirmado en CI:
+`Expected "1133224455" / Received "100000000"` (el sembrado).
 
-**Verificación:** `--repeat-each=5` contra emuladores → **5/5 pasan** (~2 s c/u, sin
-agotar el retry de 25 s). No se modificó el hook compartido `useProfile` (se evaluó pero
-se descartó para no arriesgar regresiones en todas las settings; el flake era del test).
-El hallazgo de UX de fondo queda registrado en E2E-09.
+**Fix de app (`useProfile.ts`):** se resetea el form **solo si los datos del perfil
+cambiaron de verdad** (comparación por contenido vía `JSON.stringify(profileToFormData)`
+contra `lastSyncedFormDataRef`). Un refresh async con los mismos datos ya no pisa la
+edición; tras un guardado real (datos distintos) el reset sí ocurre y limpia `isDirty`.
+Aplica a los 3 puntos de reset (mount, `loadProfile`, efecto store-sync).
+
+**Fix de test (`04-settings.spec.ts`):** esperar la **completitud** del guardado vía el
+toast (aparece tras `getProfileAction`) antes de recargar — antes recargaba sobre el
+`isSectionSaving` y abortaba el request (`ECONNRESET`, no persistía). Se mantiene el atajo
+"ya guardado" para romper el deadlock de rebaseline.
+
+**Verificación:** loop de 6 corridas con **seed fresco antes de cada una** (fuerza
+persistir desde cero) → **6/6 pasan**; `02`+`04` con `--repeat-each=4` → 11/12 antes del
+fix de app, **12/12** después.
+
+### 5c. ↩️ Regresión ronda 1: `removeChild of null` en `/dashboard/settings/general`
+**Causa:** en la ronda 1 cambié `revalidatePath('/dashboard/profile')` (no-op de años) →
+`revalidatePath('/dashboard/settings', 'layout')`. Eso refrescaba **todo el subtree del
+layout de settings** en cada guardado, re-renderizando `/general` mientras el toast y el
+`setProfile`→`reset` estaban en transición → "Cannot read properties of null (reading
+'removeChild')". Las settings son client-driven (`useProfile` ya refetchea), así que ese
+revalidate no aportaba nada.
+
+**Fix (`profile.actions.ts`):** las 12 llamadas revalidan ahora `/${session.storeId}`
+(catálogo público, consumidor real) en vez de la ruta de settings que el usuario edita.
+No se pudo reproducir el crash en Playwright headless (depende del timing real de Chrome),
+pero se eliminó la causa más probable.
+
+**Endurecimiento defensivo (auditoría DOM del proyecto):**
+- `sells/utils/sell.utils.ts` (descarga CSV): `removeChild` con guard `if (link.parentNode)`.
+- `BasicInfoSection` / `ContactInfoSection`: los `motion.div` condicionales con animación de
+  altura/entrada se envolvieron en `<AnimatePresence>` con `key` + `exit` para que
+  framer-motion controle el unmount (clase típica de `removeChild`).
+- Resto de focos auditados (DOM directo en `ThemeProvider`; `AnimatePresence` sin `key` en
+  `CartItem`/`CartFloatingButton`/`Navbar`/`ProfileHealth`): bajo riesgo, sin cambios.
+
+### 5d. ↩️ Regresión ronda 1: carrito desbordado en tablet/desktop (≥768px)
+**Causa:** a ≥768px el carrito usa `Dialog` (`grid`, items con `min-width:auto`); el nombre
+largo expandía el item más allá del modal, y la ronda 1 había quitado el `overflow-hidden`
+del `ScrollArea`. **Fix (`Cart.tsx`):** `w-full min-w-0 overflow-hidden` en el contenedor.
+Verificado con screenshot a 768px y nombre largo: trunca y queda dentro del modal.
 
 ---
 
 ## Documentación actualizada
 
-- `docs/hallazgos/testing-fase4-2026-06-22.md` — E2E-06 ✅ RESUELTO; E2E-09 ✅ RESUELTO (en el test).
+- `docs/hallazgos/testing-fase4-2026-06-22.md` — E2E-06 ✅ RESUELTO; E2E-09 ✅ RESUELTO
+  (fix de app en `useProfile` + spec endurecido).
 - `docs/hallazgos/hallazgos-por-usuarios.md` — sus dos puntos quedan resueltos (ver #2 y #4).

--- a/docs/hallazgos/fixes-ux-usuarios-2026-06-24.md
+++ b/docs/hallazgos/fixes-ux-usuarios-2026-06-24.md
@@ -1,0 +1,141 @@
+# Fixes UX — hallazgos reportados por usuarios (2026-06-24)
+
+Correcciones de cuatro problemas reportados por usuarios reales (catálogo público y
+dashboard) más un fix de CI (e2e inestable), y el cierre de hallazgos abiertos
+relacionados. Cada fix es el cambio mínimo seguro; se incluyó verificación y se
+actualizó la documentación afectada.
+
+Validación global: `npx tsc --noEmit` ✅ · `npm run lint` ✅ · `npm run test` ✅ (453 tests)
+· e2e `04-settings` 5/5 contra emuladores.
+
+---
+
+## 1. ✅ Carrito — un nombre de producto largo rompía el layout y ocultaba las acciones
+
+**Síntoma:** con un nombre largo, la fila del producto se desbordaba horizontalmente
+y el precio/total quedaban cortados fuera del panel del carrito; las acciones no se veían.
+
+**Causa raíz:** `Cart.tsx` envolvía la lista en el `ScrollArea` de Radix
+(`src/components/ui/scroll-area.tsx`). El viewport de Radix mete a los hijos en un
+contenedor con `display:table; min-width:100%`, que hace **shrink-to-fit al contenido**:
+el nombre largo expandía la fila más allá del 100%, por lo que `truncate` + `min-w-0`
+del título nunca se activaban y empujaban el precio fuera del borde.
+
+**Cambios:**
+- `src/features/store/components/cart/Cart.tsx`: se reemplazó `<ScrollArea h-80>` por un
+  `<div className="max-h-80 overflow-y-auto rounded-md">` (overflow nativo, ancho fijo al
+  contenedor). Se eliminó el scroll anidado redundante (el path mobile de `CartDrawer`
+  ya tiene su propio `overflow-y-auto`) y los imports muertos `ScrollArea` y `CartFooter`.
+- `src/features/store/components/cart/CartItem.tsx`: endurecimiento defensivo de la fila
+  inferior — `gap-2 min-w-0` en el contenedor, `flex-shrink-0` en el stepper y
+  `flex-shrink-0 whitespace-nowrap` en el precio. El título ya tenía `truncate min-w-0`.
+
+**Verificación:** agregar un producto con nombre muy largo y abrir el carrito en mobile
+(≤767px) y desktop → el nombre trunca con `…` y stepper + precio + total quedan visibles.
+
+---
+
+## 2. ✅ Dashboard "Configuración" → 404
+
+**Síntoma:** la card "Configuración" / "Personalizar tienda" del home del dashboard
+llevaba a un 404.
+
+**Causa raíz:** apuntaba a `/dashboard/profile`, ruta inexistente. Las settings viven en
+`/dashboard/settings/*` (con redirect `/dashboard/settings` → `/dashboard/settings/general`).
+Además, 12 `revalidatePath('/dashboard/profile')` revalidaban una ruta inexistente, por lo
+que las páginas reales de settings no se revalidaban tras guardar.
+
+**Cambios (`/dashboard/profile` → `/dashboard/settings`):**
+- `src/features/dashboard/modules/overview/components/DashboardWelcome.tsx` (card Configuración).
+- `src/features/dashboard/modules/overview/components/DashboardOverview.tsx` (card; título "Perfil" → "Configuración").
+- `src/features/dashboard/components/ModernTopBar.tsx`: se eliminó la key stale
+  `"/dashboard/profile"` del mapa de títulos (ya existía la correcta `"/dashboard/settings"`).
+- `src/features/dashboard/modules/store-settings/actions/profile.actions.ts`: las 12 llamadas
+  `revalidatePath('/dashboard/profile')` → `revalidatePath('/dashboard/settings', 'layout')`
+  (revalida todas las sub-rutas de settings).
+
+**Verificación:** tocar la card "Configuración" abre `/dashboard/settings/general` sin 404;
+guardar una sección refleja el cambio al recargar.
+
+---
+
+## 3. ✅ WhatsApp — a veces abría la página de descarga en vez de la app (Android/Brave; iOS)
+
+**Síntoma:** en Android (Samsung) con Brave, el primer tap en "Confirmar Pedido" no abría
+WhatsApp; redirigía al instalador. Un segundo tap (reenviar) sí lo abría.
+
+**Causa raíz:** `CheckoutForm` abría una pestaña en blanco síncrona (`window.open("", "_blank")`)
+y, **después del `await processCheckoutAction`**, le seteaba `location.href`. Tras el await se
+pierde la *user-activation* de esa pestaña, por lo que `wa.me` no dispara el intent de la app
+y cae al interstitial de descarga. (Documentado como E2E-06.)
+
+**Cambios (enfoque híbrido):**
+- `src/features/store/components/checkout/CheckoutForm.tsx`: en éxito se llama **primero** a
+  `onOrderComplete(...)` para renderizar el ticket de confirmación, y luego se intenta el
+  auto-open *best-effort* en la pestaña pre-abierta. Se eliminó el segundo `window.open`
+  post-await (el que el bloqueador de popups frena). La URL sigue siendo `https://wa.me/...`.
+- `src/features/store/components/checkout/OrderTicket.tsx`: el CTA primario es un `<a href>`
+  nativo, renombrado a **"Abrir WhatsApp"**, con copy de ayuda actualizado ("Si WhatsApp no
+  se abrió automáticamente, tocá el botón para abrirlo").
+
+**Por qué resuelve el bug:** el botón nativo del ticket abre WhatsApp sobre un gesto real del
+usuario → confiable en Android e iOS, sin depender del bloqueador de popups. El auto-open
+queda como mejor-esfuerzo.
+
+**Verificación:** completar un pedido en mobile (Android Brave/Samsung e iOS Safari). Tras
+"Confirmar Pedido" aparece el ticket con "Abrir WhatsApp"; al tocarlo abre la app con el
+mensaje. El pedido se persiste igual.
+
+---
+
+## 4. ✅ Horarios — ahora tienen su propia pestaña bajo Configuración
+
+**Síntoma / pedido:** los horarios estaban embebidos dentro de la pestaña "Ubicación";
+el hallazgo de usuarios pedía que tuvieran su propio lugar.
+
+**Cambios:**
+- Nueva ruta `src/app/dashboard/settings/schedule/page.tsx` (title "Horarios").
+- Nuevo `src/features/dashboard/modules/store-settings/components/ScheduleSettingsClient.tsx`
+  (espejo de `LocationSettingsClient`, renderiza solo `ScheduleSection`).
+- `LocationSettingsClient.tsx`: se quitó `ScheduleSection` (y el separador) — queda solo `AddressSection`.
+- `ModernSidebar.tsx`: nuevo subItem "Horarios" → `/dashboard/settings/schedule` (icono `Clock`).
+- Metadata/títulos: `location/page.tsx` → "Ubicación"; `ModernTopBar` ya mapeaba
+  `/dashboard/settings/schedule` → "Horarios" y se ajustó `/dashboard/settings/location` → "Ubicación".
+
+**Verificación:** en el sidebar de Configuración aparece "Horarios" como pestaña propia que
+abre `/dashboard/settings/schedule`; "Ubicación" ya no muestra horarios; guardar horarios persiste.
+
+---
+
+## 5. ✅ CI — e2e `04-settings` inestable (WhatsApp de contacto)
+
+**Síntoma:** el job `emulators`/`e2e` de GitHub Actions fallaba intermitente en
+`e2e/04-settings.spec.ts › edita el WhatsApp de contacto y persiste tras recargar`
+(p. ej. "1 failed, 8 passed"), incluso con `retries: 1`.
+
+**Causa raíz (no era un bug de la app):** tras un guardado exitoso, react-hook-form
+**rebasa** el form y `isDirty` vuelve a `false` con el nuevo número como baseline. El
+spec asertaba el **toast efímero** ("información de contacto guardada") dentro del
+`expect.toPass`. Cuando ese assert flaqueaba (el toast ya se había desvanecido), los
+reintentos reescribían el **mismo** número → al ser igual al baseline, RHF no volvía a
+marcar `isDirty` → el botón nunca se re-habilitaba → deadlock hasta el timeout de 25 s.
+Se confirmó reproduciendo en local contra emuladores: 4/5 fallos con el spec viejo.
+
+**Cambios (`e2e/04-settings.spec.ts`, solo el test):**
+- Ya no se asiste sobre el toast (señal efímera).
+- Cada intento detecta primero si el número **ya quedó guardado** (objetivo cumplido) y
+  retorna; rompe el deadlock de "no puedo re-ensuciar el mismo valor".
+- La señal de guardado pasa a ser estable: el botón **se deshabilita** (guardado +
+  rebaseline de RHF).
+
+**Verificación:** `--repeat-each=5` contra emuladores → **5/5 pasan** (~2 s c/u, sin
+agotar el retry de 25 s). No se modificó el hook compartido `useProfile` (se evaluó pero
+se descartó para no arriesgar regresiones en todas las settings; el flake era del test).
+El hallazgo de UX de fondo queda registrado en E2E-09.
+
+---
+
+## Documentación actualizada
+
+- `docs/hallazgos/testing-fase4-2026-06-22.md` — E2E-06 ✅ RESUELTO; E2E-09 ✅ RESUELTO (en el test).
+- `docs/hallazgos/hallazgos-por-usuarios.md` — sus dos puntos quedan resueltos (ver #2 y #4).

--- a/docs/hallazgos/hallazgos-por-usuarios.md
+++ b/docs/hallazgos/hallazgos-por-usuarios.md
@@ -1,4 +1,16 @@
-algunos links como configuracion mandan a 404, revisar bien eso, 
+# Hallazgos reportados por usuarios
 
-mejorar la estructura de las condiguraciones, horarios debe tener su propio lugar. 
+## ✅ RESUELTO (2026-06-24)
 
+Los dos puntos reportados quedaron resueltos:
+
+1. **Links como "Configuración" llevaban a 404** → corregido. La card apuntaba a
+   `/dashboard/profile` (inexistente); ahora va a `/dashboard/settings`. Se corrigieron
+   además las llamadas `revalidatePath` que apuntaban a esa ruta muerta.
+
+2. **Mejorar la estructura de las configuraciones; horarios debe tener su propio lugar**
+   → corregido. Los horarios pasaron de estar embebidos en "Ubicación" a una pestaña/ruta
+   propia: `/dashboard/settings/schedule` ("Horarios").
+
+Detalle completo de causa raíz, archivos tocados y verificación en
+[fixes-ux-usuarios-2026-06-24.md](./fixes-ux-usuarios-2026-06-24.md) (#2 y #4).

--- a/docs/hallazgos/testing-fase4-2026-06-22.md
+++ b/docs/hallazgos/testing-fase4-2026-06-22.md
@@ -206,20 +206,19 @@ reutilizando el schema Zod en ambos lados.
 
 ---
 
-## E2E-09 (Baja) — ✅ RESUELTO (en el test) — Settings: resets async reponen el form a "no-dirty"
+## E2E-09 (Media) — ✅ RESUELTO — Settings: resets async pisan la edición (pérdida de datos)
 
-> **Estado (2026-06-24):** el **spec era inestable** (fallaba intermitente en CI,
-> incluso con `retries: 1`). Causa raíz del flake: tras un guardado exitoso,
-> react-hook-form rebasa el form y `isDirty` vuelve a `false` con el nuevo número
-> como baseline; el spec asertaba el **toast efímero** dentro del `toPass` y, cuando
-> ese assert flaqueaba, los reintentos reescribían el MISMO número → no volvían a
-> ensuciar el form → deadlock hasta el timeout de 25 s. Se endureció el spec: ya no
-> asiste sobre el toast, detecta si el número ya quedó guardado (objetivo cumplido) y
-> usa una señal estable (botón se deshabilita = guardado + rebaseline). Verificado
-> 5/5 en local contra emuladores (`--repeat-each=5`). El **hallazgo de UX de fondo**
-> (un usuario que edita muy rápido podría ver el botón deshabilitarse por un refresh
-> async) sigue siendo válido pero menor; no se tocó el hook compartido para evitar
-> riesgo de regresión. Ver [fixes-ux-usuarios-2026-06-24.md](./fixes-ux-usuarios-2026-06-24.md) (#5).
+> **Estado (2026-06-25):** corregido en la **app**, no solo en el test. Resultó ser un
+> bug real de **pérdida de datos**: con varias instancias de `useProfile` compartiendo el
+> store, un `setProfile` async dispara `reset(form)` que pisa la edición en curso e
+> `isDirty` vuelve a `false`; `handleSectionSave` guarda entonces el valor viejo (el toast
+> dice "guardado" pero persiste lo anterior). Confirmado en CI:
+> `Expected "1133224455" / Received "100000000"`.
+> **Fix (`useProfile.ts`):** resetear el form solo si los datos del perfil cambiaron de
+> verdad (comparación por contenido contra `lastSyncedFormDataRef`), en los 3 puntos de
+> reset. **Fix de test (`04-settings.spec.ts`):** esperar la completitud del guardado (toast
+> tras `getProfileAction`) antes de recargar. Verificado: 6/6 con seed fresco por corrida.
+> Ver [fixes-ux-usuarios-2026-06-24.md](./fixes-ux-usuarios-2026-06-24.md) (#5b).
 
 **Archivos:**
 - `e2e/04-settings.spec.ts` (spec endurecido)
@@ -287,7 +286,7 @@ completa (9 tests, 5 archivos) corre verde tanto en Node 22 (CI) como en Node 24
 | E2E-06 | Baja | ✅ Resuelto | Checkout abre WhatsApp por popup |
 | E2E-07 | Media | 📄 Documentado | Sesión no reutilizable vía storageState |
 | E2E-08 | Media | ✅ Resuelto | Reglas de contraseña cliente ≠ servidor |
-| E2E-09 | Baja | ✅ Resuelto (test) | Settings: reset async borra el dirty |
+| E2E-09 | Media | ✅ Resuelto (app+test) | Settings: reset async pisa la edición (pérdida de datos) |
 | E2E-10 | Baja | ✅ Resuelto (en test) | Modal de bienvenida se solapa con el carrito |
 
 Ninguno es bloqueante para el merge de la Fase 4. Se corrigieron E2E-01/03/04/05/10

--- a/docs/hallazgos/testing-fase4-2026-06-22.md
+++ b/docs/hallazgos/testing-fase4-2026-06-22.md
@@ -123,7 +123,17 @@ Pendiente (no bloqueante): asociar cada `label` con su input vía `htmlFor`/`id`
 
 ---
 
-## E2E-06 (Baja) — 📄 documentado — Checkout abre WhatsApp con `window.open` (popup)
+## E2E-06 (Baja) — ✅ RESUELTO — Checkout abre WhatsApp con `window.open` (popup)
+
+> **Estado (2026-06-24):** corregido con enfoque **híbrido**. `CheckoutForm` ahora
+> renderiza **siempre primero** el ticket de confirmación (`OrderTicket`), que expone
+> un `<a href=wa.me target="_blank">` nativo "Abrir WhatsApp" — camino 100% confiable
+> en Android e iOS porque corre sobre un gesto real del usuario. El auto-open en la
+> pestaña pre-abierta queda como *best-effort* (ya no se hace un segundo `window.open`
+> post-await, que era el que el bloqueador frenaba). Esto resuelve el bug reportado por
+> usuarios (Brave/Android caía al interstitial de descarga en el primer tap).
+> Ver [docs/hallazgos/fixes-ux-usuarios-2026-06-24.md](./fixes-ux-usuarios-2026-06-24.md) (#3).
+
 
 **Archivo:** `src/features/store/components/checkout/CheckoutForm.tsx` (~L254, L276)
 
@@ -196,9 +206,23 @@ reutilizando el schema Zod en ambos lados.
 
 ---
 
-## E2E-09 (Baja) — 📄 documentado — Settings: resets async reponen el form a "no-dirty"
+## E2E-09 (Baja) — ✅ RESUELTO (en el test) — Settings: resets async reponen el form a "no-dirty"
+
+> **Estado (2026-06-24):** el **spec era inestable** (fallaba intermitente en CI,
+> incluso con `retries: 1`). Causa raíz del flake: tras un guardado exitoso,
+> react-hook-form rebasa el form y `isDirty` vuelve a `false` con el nuevo número
+> como baseline; el spec asertaba el **toast efímero** dentro del `toPass` y, cuando
+> ese assert flaqueaba, los reintentos reescribían el MISMO número → no volvían a
+> ensuciar el form → deadlock hasta el timeout de 25 s. Se endureció el spec: ya no
+> asiste sobre el toast, detecta si el número ya quedó guardado (objetivo cumplido) y
+> usa una señal estable (botón se deshabilita = guardado + rebaseline). Verificado
+> 5/5 en local contra emuladores (`--repeat-each=5`). El **hallazgo de UX de fondo**
+> (un usuario que edita muy rápido podría ver el botón deshabilitarse por un refresh
+> async) sigue siendo válido pero menor; no se tocó el hook compartido para evitar
+> riesgo de regresión. Ver [fixes-ux-usuarios-2026-06-24.md](./fixes-ux-usuarios-2026-06-24.md) (#5).
 
 **Archivos:**
+- `e2e/04-settings.spec.ts` (spec endurecido)
 - `src/features/dashboard/modules/store-settings/hooks/useProfile.ts` (`reset(formData)`)
 - `.../sections/ContactInfoSection.tsx` (`disabled={isSectionSaving || !formState.isDirty}`)
 
@@ -260,10 +284,10 @@ completa (9 tests, 5 archivos) corre verde tanto en Node 22 (CI) como en Node 24
 | E2E-03 | Media | ✅ Resuelto | Testid de guardado en settings (las 3 secciones) |
 | E2E-04 | Media | ✅ Resuelto | Testid de navegación en onboarding |
 | E2E-05 | Baja | ✅ Resuelto (parcial) | Testid de precio en form de producto |
-| E2E-06 | Baja | 📄 Documentado | Checkout abre WhatsApp por popup |
+| E2E-06 | Baja | ✅ Resuelto | Checkout abre WhatsApp por popup |
 | E2E-07 | Media | 📄 Documentado | Sesión no reutilizable vía storageState |
 | E2E-08 | Media | ✅ Resuelto | Reglas de contraseña cliente ≠ servidor |
-| E2E-09 | Baja | 📄 Documentado | Settings: reset async borra el dirty |
+| E2E-09 | Baja | ✅ Resuelto (test) | Settings: reset async borra el dirty |
 | E2E-10 | Baja | ✅ Resuelto (en test) | Modal de bienvenida se solapa con el carrito |
 
 Ninguno es bloqueante para el merge de la Fase 4. Se corrigieron E2E-01/03/04/05/10

--- a/docs/test/40-e2e-guide.md
+++ b/docs/test/40-e2e-guide.md
@@ -83,7 +83,7 @@ test('checkout genera el total recalculado y link de WhatsApp', async ({ page, c
 
   await expect(page.getByText(/pedido confirmado/i)).toBeVisible();
   await expect(page.getByText(new RegExp(priceDigits(SEED.PRODUCT.price))).first()).toBeVisible();
-  await expect(page.getByRole('link', { name: /reenviar por whatsapp/i }))
+  await expect(page.getByRole('link', { name: /abrir whatsapp/i }))
     .toHaveAttribute('href', /wa\.me/);
 });
 ```

--- a/e2e/02-catalog-checkout.spec.ts
+++ b/e2e/02-catalog-checkout.spec.ts
@@ -75,7 +75,7 @@ test.describe('Catálogo público → checkout → WhatsApp', () => {
 
     // El link de WhatsApp del pedido apunta a wa.me.
     await expect(
-      page.getByRole('link', { name: /reenviar por whatsapp/i }),
+      page.getByRole('link', { name: /abrir whatsapp/i }),
     ).toHaveAttribute('href', /wa\.me/);
   });
 

--- a/e2e/04-settings.spec.ts
+++ b/e2e/04-settings.spec.ts
@@ -18,16 +18,25 @@ test('edita el WhatsApp de contacto y persiste tras recargar', async ({ page }) 
   const whatsapp = page.getByLabel(/whatsapp/i);
   await expect(whatsapp).toHaveValue(/\d{3,}/);
 
+  const saveContact = page.getByTestId('save-contact');
+
   // El perfil dispara resets async que reponen el form a no-dirty (hallazgo
   // E2E-09): reintentar editar+guardar hasta que el guardado tome efecto.
-  const saveContact = page.getByTestId('save-contact');
+  //
+  // Importante: NO se asiste sobre el toast (es efímero y se desvanece). Si un
+  // intento previo ya guardó, react-hook-form rebasa el form y `isDirty` vuelve a
+  // `false` con el nuevo número como baseline; en ese caso reescribir el MISMO
+  // número no vuelve a habilitar el botón. Por eso cada intento detecta primero si
+  // el número ya quedó guardado (objetivo cumplido) y, si no, edita y espera a que
+  // el botón se deshabilite de nuevo (señal estable de guardado + rebaseline).
   await expect(async () => {
+    const current = (await whatsapp.inputValue()).replace(/\D/g, '');
+    if (current.includes(newNumber)) return;
+
     await whatsapp.fill(newNumber);
     await expect(saveContact).toBeEnabled({ timeout: 2_000 });
     await saveContact.click({ timeout: 2_000 });
-    await expect(
-      page.getByText(/información de contacto guardada/i),
-    ).toBeVisible({ timeout: 3_000 });
+    await expect(saveContact).toBeDisabled({ timeout: 3_000 });
   }).toPass({ timeout: 25_000 });
 
   // Recargar y confirmar que el número quedó persistido (comparando solo dígitos,

--- a/e2e/04-settings.spec.ts
+++ b/e2e/04-settings.spec.ts
@@ -23,21 +23,30 @@ test('edita el WhatsApp de contacto y persiste tras recargar', async ({ page }) 
   // El perfil dispara resets async que reponen el form a no-dirty (hallazgo
   // E2E-09): reintentar editar+guardar hasta que el guardado tome efecto.
   //
-  // Importante: NO se asiste sobre el toast (es efímero y se desvanece). Si un
-  // intento previo ya guardó, react-hook-form rebasa el form y `isDirty` vuelve a
-  // `false` con el nuevo número como baseline; en ese caso reescribir el MISMO
-  // número no vuelve a habilitar el botón. Por eso cada intento detecta primero si
-  // el número ya quedó guardado (objetivo cumplido) y, si no, edita y espera a que
-  // el botón se deshabilite de nuevo (señal estable de guardado + rebaseline).
+  // Claves de robustez:
+  // - Si un intento previo YA guardó, react-hook-form rebasa el form e `isDirty`
+  //   vuelve a `false` con el nuevo número como baseline; reescribir el MISMO número
+  //   no vuelve a ensuciar el form. Por eso cada intento detecta primero si el número
+  //   ya quedó guardado (valor + botón deshabilitado = guardado + rebaseline) y corta.
+  // - Se ESPERA la completitud real del guardado vía el toast "información de contacto
+  //   guardada", que aparece recién después de `updateContactInfoAction` +
+  //   `getProfileAction`. NO basta `toBeDisabled` tras el click: el botón también se
+  //   deshabilita por `isSectionSaving` (guardado en vuelo), y recargar en ese momento
+  //   aborta el request (no persiste).
   await expect(async () => {
     const current = (await whatsapp.inputValue()).replace(/\D/g, '');
-    if (current.includes(newNumber)) return;
+    if (current.includes(newNumber)) {
+      await expect(saveContact).toBeDisabled({ timeout: 1_000 });
+      return;
+    }
 
     await whatsapp.fill(newNumber);
     await expect(saveContact).toBeEnabled({ timeout: 2_000 });
     await saveContact.click({ timeout: 2_000 });
-    await expect(saveContact).toBeDisabled({ timeout: 3_000 });
-  }).toPass({ timeout: 25_000 });
+    await expect(
+      page.getByText(/información de contacto guardada/i),
+    ).toBeVisible({ timeout: 6_000 });
+  }).toPass({ timeout: 30_000 });
 
   // Recargar y confirmar que el número quedó persistido (comparando solo dígitos,
   // tolerante a que el número se reformatee con espacios/guiones).

--- a/src/app/dashboard/settings/location/page.tsx
+++ b/src/app/dashboard/settings/location/page.tsx
@@ -1,7 +1,7 @@
 import LocationSettingsClient from "@/features/dashboard/modules/store-settings/components/LocationSettingsClient";
 
 export const metadata = {
-  title: 'Configuración de Ubicación y Horarios | Dashboard',
+  title: 'Configuración de Ubicación | Dashboard',
 };
 
 export default function LocationSettingsPage() {

--- a/src/app/dashboard/settings/schedule/page.tsx
+++ b/src/app/dashboard/settings/schedule/page.tsx
@@ -1,0 +1,9 @@
+import ScheduleSettingsClient from "@/features/dashboard/modules/store-settings/components/ScheduleSettingsClient";
+
+export const metadata = {
+  title: 'Horarios | Dashboard',
+};
+
+export default function ScheduleSettingsPage() {
+  return <ScheduleSettingsClient />;
+}

--- a/src/features/dashboard/components/ModernSidebar.tsx
+++ b/src/features/dashboard/components/ModernSidebar.tsx
@@ -34,6 +34,7 @@ import {
   Palette,
   MapPin,
   CreditCard,
+  Clock,
   UserCircle
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -115,6 +116,11 @@ const navigationItems = [
         title: "Ubicación",
         href: "/dashboard/settings/location",
         icon: MapPin,
+      },
+      {
+        title: "Horarios",
+        href: "/dashboard/settings/schedule",
+        icon: Clock,
       },
       {
         title: "Pagos y Entregas",

--- a/src/features/dashboard/components/ModernTopBar.tsx
+++ b/src/features/dashboard/components/ModernTopBar.tsx
@@ -56,7 +56,6 @@ const routeTitles: Record<string, string> = {
   "/dashboard/products": "Productos",
   "/dashboard/sells": "Ventas",
   "/dashboard/sells/new": "Nueva Venta",
-  "/dashboard/profile": "Configuración",
   "/dashboard/subscription": "Suscripción",
   "/dashboard/qr": "QR Menu",
   "/dashboard/guides": "Guía de Usuario",
@@ -64,7 +63,7 @@ const routeTitles: Record<string, string> = {
   "/dashboard/settings/general": "General",
   "/dashboard/settings/appearance": "Apariencia",
   "/dashboard/settings/checkout": "Pagos y Entregas",
-  "/dashboard/settings/location": "Ubicación y Horarios",
+  "/dashboard/settings/location": "Ubicación",
   "/dashboard/settings/schedule": "Horarios",
   "/dashboard/settings/notifications": "Notificaciones",
 };

--- a/src/features/dashboard/modules/overview/components/DashboardOverview.tsx
+++ b/src/features/dashboard/modules/overview/components/DashboardOverview.tsx
@@ -94,10 +94,10 @@ const DashboardOverview: React.FC = () => {
       stats: '0 ventas'
     },
     {
-      title: 'Perfil',
+      title: 'Configuración',
       description: 'Configuración de la tienda',
       icon: Settings,
-      path: '/dashboard/profile',
+      path: '/dashboard/settings',
       stats: 'Configurar'
     },
     {

--- a/src/features/dashboard/modules/overview/components/DashboardWelcome.tsx
+++ b/src/features/dashboard/modules/overview/components/DashboardWelcome.tsx
@@ -346,7 +346,7 @@ const DashboardWelcome: React.FC<DashboardWelcomeProps> = ({
       icon: Settings,
       iconBg: "bg-slate-50",
       iconColor: "text-slate-600",
-      path: "/dashboard/profile",
+      path: "/dashboard/settings",
     },
     {
       title: "Código QR",

--- a/src/features/dashboard/modules/sells/utils/sell.utils.ts
+++ b/src/features/dashboard/modules/sells/utils/sell.utils.ts
@@ -265,8 +265,13 @@ export function downloadCSV(content: string, filename: string): void {
   
   link.setAttribute('href', url);
   link.setAttribute('download', filename);
+  link.style.display = 'none';
   document.body.appendChild(link);
   link.click();
-  document.body.removeChild(link);
+  // Quitar el nodo de forma defensiva: si algo (React, otra lógica) ya lo removió,
+  // `removeChild` lanzaría "Cannot read properties of null (reading 'removeChild')".
+  if (link.parentNode) {
+    link.parentNode.removeChild(link);
+  }
   URL.revokeObjectURL(url);
 }

--- a/src/features/dashboard/modules/store-settings/actions/profile.actions.ts
+++ b/src/features/dashboard/modules/store-settings/actions/profile.actions.ts
@@ -99,7 +99,7 @@ export async function updateProfileAction(
     await profileServerService.updateProfile(session.storeId, validation.data);
     
     // 4. REVALIDATE
-    revalidatePath('/dashboard/profile');
+    revalidatePath('/dashboard/settings', 'layout');
     revalidatePath(`/${session.storeId}`);
     
     return { success: true, data: { updated: true } };
@@ -148,7 +148,7 @@ export async function updateBasicInfoAction(
     await profileServerService.updateBasicInfo(session.storeId, validation.data);
     
     // 5. REVALIDATE
-    revalidatePath('/dashboard/profile');
+    revalidatePath('/dashboard/settings', 'layout');
     
     return { success: true, data: { updated: true } };
   } catch (error) {
@@ -188,7 +188,7 @@ export async function updateContactInfoAction(
     await profileServerService.updateContactInfo(session.storeId, validation.data);
     
     // 4. REVALIDATE
-    revalidatePath('/dashboard/profile');
+    revalidatePath('/dashboard/settings', 'layout');
     
     return { success: true, data: { updated: true } };
   } catch (error) {
@@ -228,7 +228,7 @@ export async function updateAddressAction(
     await profileServerService.updateAddress(session.storeId, validation.data);
     
     // 4. REVALIDATE
-    revalidatePath('/dashboard/profile');
+    revalidatePath('/dashboard/settings', 'layout');
     
     return { success: true, data: { updated: true } };
   } catch (error) {
@@ -268,7 +268,7 @@ export async function updateSocialLinksAction(
     await profileServerService.updateSocialLinks(session.storeId, validation.data);
     
     // 4. REVALIDATE
-    revalidatePath('/dashboard/profile');
+    revalidatePath('/dashboard/settings', 'layout');
     
     return { success: true, data: { updated: true } };
   } catch (error) {
@@ -308,7 +308,7 @@ export async function updateThemeAction(
     await profileServerService.updateTheme(session.storeId, validation.data);
     
     // 4. REVALIDATE
-    revalidatePath('/dashboard/profile');
+    revalidatePath('/dashboard/settings', 'layout');
     
     return { success: true, data: { updated: true } };
   } catch (error) {
@@ -374,7 +374,7 @@ export async function updatePaymentMethodsAction(
     await profileServerService.updateSettings(session.storeId, { paymentMethods });
     
     // 3. REVALIDATE
-    revalidatePath('/dashboard/profile');
+    revalidatePath('/dashboard/settings', 'layout');
     
     return { success: true, data: { updated: true } };
   } catch (error) {
@@ -409,7 +409,7 @@ export async function updateDeliveryMethodsAction(
     await profileServerService.updateSettings(session.storeId, { deliveryMethods });
     
     // 3. REVALIDATE
-    revalidatePath('/dashboard/profile');
+    revalidatePath('/dashboard/settings', 'layout');
     
     return { success: true, data: { updated: true } };
   } catch (error) {
@@ -441,7 +441,7 @@ export async function updateScheduleAction(
     await profileServerService.updateSchedule(session.storeId, schedule);
     
     // 3. REVALIDATE
-    revalidatePath('/dashboard/profile');
+    revalidatePath('/dashboard/settings', 'layout');
     
     return { success: true, data: { updated: true } };
   } catch (error) {
@@ -487,7 +487,7 @@ export async function updatePaymentDeliveryAction(
     });
     
     // 3. REVALIDATE
-    revalidatePath('/dashboard/profile');
+    revalidatePath('/dashboard/settings', 'layout');
     
     return { success: true, data: { updated: true } };
   } catch (error) {
@@ -523,7 +523,7 @@ export async function updateSubscriptionAction(
     await profileServerService.updateSettings(session.storeId, { subscription });
     
     // 3. REVALIDATE
-    revalidatePath('/dashboard/profile');
+    revalidatePath('/dashboard/settings', 'layout');
     
     return { success: true, data: { updated: true } };
   } catch (error) {

--- a/src/features/dashboard/modules/store-settings/actions/profile.actions.ts
+++ b/src/features/dashboard/modules/store-settings/actions/profile.actions.ts
@@ -99,9 +99,12 @@ export async function updateProfileAction(
     await profileServerService.updateProfile(session.storeId, validation.data);
     
     // 4. REVALIDATE
-    revalidatePath('/dashboard/settings', 'layout');
+    // Solo el catálogo público (consumidor real de estos datos). NO se revalida
+    // la ruta de settings: es client-driven (useProfile refetchea) y revalidar su
+    // layout mientras el usuario edita re-renderiza el subtree en pleno guardado,
+    // lo que dispara "Cannot read properties of null (reading 'removeChild')".
     revalidatePath(`/${session.storeId}`);
-    
+
     return { success: true, data: { updated: true } };
   } catch (error) {
     console.error('Error updating profile:', error);
@@ -148,7 +151,7 @@ export async function updateBasicInfoAction(
     await profileServerService.updateBasicInfo(session.storeId, validation.data);
     
     // 5. REVALIDATE
-    revalidatePath('/dashboard/settings', 'layout');
+    revalidatePath(`/${session.storeId}`);
     
     return { success: true, data: { updated: true } };
   } catch (error) {
@@ -186,9 +189,9 @@ export async function updateContactInfoAction(
   try {
     // 3. MUTATE
     await profileServerService.updateContactInfo(session.storeId, validation.data);
-    
+
     // 4. REVALIDATE
-    revalidatePath('/dashboard/settings', 'layout');
+    revalidatePath(`/${session.storeId}`);
     
     return { success: true, data: { updated: true } };
   } catch (error) {
@@ -228,7 +231,7 @@ export async function updateAddressAction(
     await profileServerService.updateAddress(session.storeId, validation.data);
     
     // 4. REVALIDATE
-    revalidatePath('/dashboard/settings', 'layout');
+    revalidatePath(`/${session.storeId}`);
     
     return { success: true, data: { updated: true } };
   } catch (error) {
@@ -268,7 +271,7 @@ export async function updateSocialLinksAction(
     await profileServerService.updateSocialLinks(session.storeId, validation.data);
     
     // 4. REVALIDATE
-    revalidatePath('/dashboard/settings', 'layout');
+    revalidatePath(`/${session.storeId}`);
     
     return { success: true, data: { updated: true } };
   } catch (error) {
@@ -308,7 +311,7 @@ export async function updateThemeAction(
     await profileServerService.updateTheme(session.storeId, validation.data);
     
     // 4. REVALIDATE
-    revalidatePath('/dashboard/settings', 'layout');
+    revalidatePath(`/${session.storeId}`);
     
     return { success: true, data: { updated: true } };
   } catch (error) {
@@ -374,7 +377,7 @@ export async function updatePaymentMethodsAction(
     await profileServerService.updateSettings(session.storeId, { paymentMethods });
     
     // 3. REVALIDATE
-    revalidatePath('/dashboard/settings', 'layout');
+    revalidatePath(`/${session.storeId}`);
     
     return { success: true, data: { updated: true } };
   } catch (error) {
@@ -409,7 +412,7 @@ export async function updateDeliveryMethodsAction(
     await profileServerService.updateSettings(session.storeId, { deliveryMethods });
     
     // 3. REVALIDATE
-    revalidatePath('/dashboard/settings', 'layout');
+    revalidatePath(`/${session.storeId}`);
     
     return { success: true, data: { updated: true } };
   } catch (error) {
@@ -441,7 +444,7 @@ export async function updateScheduleAction(
     await profileServerService.updateSchedule(session.storeId, schedule);
     
     // 3. REVALIDATE
-    revalidatePath('/dashboard/settings', 'layout');
+    revalidatePath(`/${session.storeId}`);
     
     return { success: true, data: { updated: true } };
   } catch (error) {
@@ -487,7 +490,7 @@ export async function updatePaymentDeliveryAction(
     });
     
     // 3. REVALIDATE
-    revalidatePath('/dashboard/settings', 'layout');
+    revalidatePath(`/${session.storeId}`);
     
     return { success: true, data: { updated: true } };
   } catch (error) {
@@ -523,7 +526,7 @@ export async function updateSubscriptionAction(
     await profileServerService.updateSettings(session.storeId, { subscription });
     
     // 3. REVALIDATE
-    revalidatePath('/dashboard/settings', 'layout');
+    revalidatePath(`/${session.storeId}`);
     
     return { success: true, data: { updated: true } };
   } catch (error) {

--- a/src/features/dashboard/modules/store-settings/components/ScheduleSettingsClient.tsx
+++ b/src/features/dashboard/modules/store-settings/components/ScheduleSettingsClient.tsx
@@ -2,9 +2,9 @@
 
 import React, { useCallback } from 'react';
 import { useProfile } from '../hooks/useProfile';
-import { AddressSection } from './sections/AddressSection';
+import { ScheduleSection } from './sections/ScheduleSection';
 
-export default function LocationSettingsClient() {
+export default function ScheduleSettingsClient() {
   const {
     profile,
     formData,
@@ -34,7 +34,7 @@ export default function LocationSettingsClient() {
 
   return (
     <div className="space-y-8 w-full">
-      <AddressSection {...sectionProps} />
+      <ScheduleSection {...sectionProps} />
     </div>
   );
 }

--- a/src/features/dashboard/modules/store-settings/components/sections/BasicInfoSection.tsx
+++ b/src/features/dashboard/modules/store-settings/components/sections/BasicInfoSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
-import { motion } from 'framer-motion';
+import { motion, AnimatePresence } from 'framer-motion';
 import { toast } from 'sonner';
 import { debounce } from 'lodash';
 import { ProfileFormData, FormState, StoreProfile } from '../../types/store.type';
@@ -375,27 +375,34 @@ Ante cualquier consulta, estamos a disposición. 😊`;
               </p>
             </div>
 
-            {/* Preview Box */}
-            {formData.siteName && (
-              <motion.div
-                initial={{ opacity: 0, height: 0 }}
-                animate={{ opacity: 1, height: 'auto' }}
-                className="bg-indigo-50/50 border border-indigo-100 rounded-xl p-4"
-              >
-                <h4 className="text-xs font-semibold text-indigo-900 uppercase tracking-wider mb-2">
-                  Vista Previa del Enlace
-                </h4>
-                <div className="flex items-center gap-2 text-indigo-700 bg-white border border-indigo-200 py-2 px-3 rounded-lg overflow-hidden">
-                  <Globe className="w-4 h-4 flex-shrink-0" />
-                  <span className="text-sm font-medium truncate">
-                    tutiendaweb.com.ar/{formData.siteName}
-                  </span>
-                </div>
-                <p className="text-xs text-indigo-600/80 mt-2">
-                  Comparte este enlace con tus clientes en redes sociales y WhatsApp.
-                </p>
-              </motion.div>
-            )}
+            {/* Preview Box — dentro de AnimatePresence para que framer-motion
+                controle el unmount (animación de altura). Sin esto, al desaparecer
+                `siteName` React removía el nodo mientras la animación seguía viva,
+                lo que puede lanzar "removeChild of null". */}
+            <AnimatePresence initial={false}>
+              {formData.siteName && (
+                <motion.div
+                  key="site-name-preview"
+                  initial={{ opacity: 0, height: 0 }}
+                  animate={{ opacity: 1, height: 'auto' }}
+                  exit={{ opacity: 0, height: 0 }}
+                  className="bg-indigo-50/50 border border-indigo-100 rounded-xl p-4"
+                >
+                  <h4 className="text-xs font-semibold text-indigo-900 uppercase tracking-wider mb-2">
+                    Vista Previa del Enlace
+                  </h4>
+                  <div className="flex items-center gap-2 text-indigo-700 bg-white border border-indigo-200 py-2 px-3 rounded-lg overflow-hidden">
+                    <Globe className="w-4 h-4 flex-shrink-0" />
+                    <span className="text-sm font-medium truncate">
+                      tutiendaweb.com.ar/{formData.siteName}
+                    </span>
+                  </div>
+                  <p className="text-xs text-indigo-600/80 mt-2">
+                    Comparte este enlace con tus clientes en redes sociales y WhatsApp.
+                  </p>
+                </motion.div>
+              )}
+            </AnimatePresence>
           </div>
         </CardContent>
       </Card>

--- a/src/features/dashboard/modules/store-settings/components/sections/ContactInfoSection.tsx
+++ b/src/features/dashboard/modules/store-settings/components/sections/ContactInfoSection.tsx
@@ -10,7 +10,7 @@
 'use client';
 
 import React, { useState, useCallback, useEffect, useRef, useTransition } from 'react';
-import { motion } from 'framer-motion';
+import { motion, AnimatePresence } from 'framer-motion';
 import { ProfileFormData, FormState, StoreProfile } from '../../types/store.type';
 import { updateContactInfoAction, getProfileAction } from '../../actions/profile.actions';
 import { useProfileStore } from '../../stores/profile.store';
@@ -275,16 +275,22 @@ export function ContactInfoSection({
           </div>
         </div>
 
-        {formState.errors.whatsapp && (
-          <motion.div
-            initial={{ opacity: 0, x: -10 }}
-            animate={{ opacity: 1, x: 0 }}
-            className="flex items-center space-x-2 p-3 bg-red-50 border border-red-200 rounded-lg"
-          >
-            <AlertCircle className="w-5 h-5 text-red-500 flex-shrink-0" />
-            <span className="text-sm text-red-700 font-medium">{formState.errors.whatsapp}</span>
-          </motion.div>
-        )}
+        {/* Mensaje de error dentro de AnimatePresence: framer-motion controla el
+            unmount y evita "removeChild of null" al togglear el error mientras se tipea. */}
+        <AnimatePresence initial={false}>
+          {formState.errors.whatsapp && (
+            <motion.div
+              key="whatsapp-error"
+              initial={{ opacity: 0, x: -10 }}
+              animate={{ opacity: 1, x: 0 }}
+              exit={{ opacity: 0, x: -10 }}
+              className="flex items-center space-x-2 p-3 bg-red-50 border border-red-200 rounded-lg"
+            >
+              <AlertCircle className="w-5 h-5 text-red-500 flex-shrink-0" />
+              <span className="text-sm text-red-700 font-medium">{formState.errors.whatsapp}</span>
+            </motion.div>
+          )}
+        </AnimatePresence>
       </motion.div>
 
       {/* Consejos - Diseño moderno */}

--- a/src/features/dashboard/modules/store-settings/hooks/useProfile.ts
+++ b/src/features/dashboard/modules/store-settings/hooks/useProfile.ts
@@ -120,6 +120,14 @@ export const useProfile = (options: UseProfileOptions = {}) => {
 
   const { watch, setValue, getValues, formState: { isDirty, errors }, reset } = form;
 
+  // Última versión de los datos del form ya sincronizada desde el perfil. Sirve
+  // para NO re-resetear el form cuando un refresh async trae los MISMOS datos
+  // (varias instancias de useProfile comparten el store): si se reseteara, se
+  // pisaría lo que el usuario está editando y `isDirty` volvería a `false`,
+  // provocando que el guardado tome el valor viejo (hallazgo E2E-09 — pérdida de
+  // datos). Tras un guardado real los datos cambian, así que el reset sí ocurre.
+  const lastSyncedFormDataRef = useRef<string>('');
+
   /**
    * Cargar perfil del usuario usando Server Action
    */
@@ -156,9 +164,14 @@ export const useProfile = (options: UseProfileOptions = {}) => {
           stats: { missingFields, lastUpdated },
         }));
 
-        // Cargar datos en el formulario - reset completo con los datos del perfil
+        // Cargar datos en el formulario solo si cambiaron de verdad: así un
+        // refresh async no pisa las ediciones sin guardar del usuario (E2E-09).
         const formData = profileToFormData(loadedProfile);
-        reset(formData);
+        const formDataKey = JSON.stringify(formData);
+        if (formDataKey !== lastSyncedFormDataRef.current) {
+          reset(formData);
+          lastSyncedFormDataRef.current = formDataKey;
+        }
       }
       
       setIsLoading(false);
@@ -343,6 +356,7 @@ export const useProfile = (options: UseProfileOptions = {}) => {
       // También inicializar el formulario con estos datos
       const formData = profileToFormData(profile);
       reset(formData);
+      lastSyncedFormDataRef.current = JSON.stringify(formData);
     }
   }, [user?.uid, profile, storeProfile, loadProfile, setProfile, reset]);
 
@@ -358,9 +372,16 @@ export const useProfile = (options: UseProfileOptions = {}) => {
     );
     
     if (shouldSync) {
+      // Resetear el form SOLO en el primer sync o cuando los datos cambiaron de
+      // verdad. Un setProfile async con los MISMOS datos (otra instancia de
+      // useProfile, re-fetch) no debe pisar las ediciones en curso (E2E-09).
       const formData = profileToFormData(storeProfile);
-      reset(formData);
-      
+      const formDataKey = JSON.stringify(formData);
+      if (isFirstSyncRef.current || formDataKey !== lastSyncedFormDataRef.current) {
+        reset(formData);
+        lastSyncedFormDataRef.current = formDataKey;
+      }
+
       const missingFields = getMissingFields(storeProfile);
       const lastUpdated = storeProfile.metadata?.updatedAt
         ? new Date(storeProfile.metadata.updatedAt)

--- a/src/features/store/components/cart/Cart.tsx
+++ b/src/features/store/components/cart/Cart.tsx
@@ -9,8 +9,6 @@
 "use client";
 import { Topics } from "@/shared/types/store";
 import CartItem from "./CartItem";
-import CartFooter from "./CartFooter";
-import { ScrollArea } from "@/components/ui/scroll-area";
 
 interface CartProps {
   items: {
@@ -45,8 +43,13 @@ const Cart = ({
       className="flex flex-col h-full max-h-[50vh] rounded-lg"
       style={{ backgroundColor: 'var(--store-secondary, #f9fafb)' }}
     >
-      {/* Área scrolleable de productos */}
-      <ScrollArea className="h-80 rounded-md">
+      {/* Área scrolleable de productos.
+          Se usa un div con overflow nativo (no Radix ScrollArea) porque el
+          viewport de ScrollArea envuelve a los hijos en un layout `display:table`
+          que hace shrink-to-fit al contenido: un nombre de producto largo expandía
+          la fila más allá del 100% y rompía el truncate, empujando el precio fuera
+          del panel. Con overflow nativo el ancho queda fijo al contenedor. */}
+      <div className="max-h-80 overflow-y-auto rounded-md">
         <div className="p-4 space-y-4">
           {items.map((item) => (
             <CartItem
@@ -58,7 +61,7 @@ const Cart = ({
             />
           ))}
         </div>
-      </ScrollArea>
+      </div>
     </div>
   );
 };

--- a/src/features/store/components/cart/Cart.tsx
+++ b/src/features/store/components/cart/Cart.tsx
@@ -40,7 +40,7 @@ const Cart = ({
 }: CartProps) => {
   return (
     <div
-      className="flex flex-col h-full max-h-[50vh] rounded-lg"
+      className="flex flex-col h-full max-h-[50vh] w-full min-w-0 overflow-hidden rounded-lg"
       style={{ backgroundColor: 'var(--store-secondary, #f9fafb)' }}
     >
       {/* Área scrolleable de productos.
@@ -48,8 +48,13 @@ const Cart = ({
           viewport de ScrollArea envuelve a los hijos en un layout `display:table`
           que hace shrink-to-fit al contenido: un nombre de producto largo expandía
           la fila más allá del 100% y rompía el truncate, empujando el precio fuera
-          del panel. Con overflow nativo el ancho queda fijo al contenedor. */}
-      <div className="max-h-80 overflow-y-auto rounded-md">
+          del panel. Con overflow nativo el ancho queda fijo al contenedor.
+
+          `w-full min-w-0 overflow-hidden` en el contenedor raíz es clave para el
+          modal de desktop: `DialogContent` es un `grid` y sus items tienen
+          `min-width: auto`, así que sin `min-w-0` el nombre largo expandía el
+          carrito más allá del ancho del modal (se salía de la tarjeta). */}
+      <div className="max-h-80 overflow-y-auto overflow-x-hidden rounded-md">
         <div className="p-4 space-y-4">
           {items.map((item) => (
             <CartItem

--- a/src/features/store/components/cart/CartItem.tsx
+++ b/src/features/store/components/cart/CartItem.tsx
@@ -167,8 +167,8 @@ const CartItem = ({ product, onQuantityChange, onRemove, onEditTopics }: CartIte
           )}
 
           {/* Cantidad + subtotal */}
-          <div className="flex items-center justify-between mt-2">
-            <div className="flex items-center rounded-full border border-gray-200 bg-gray-50 overflow-hidden">
+          <div className="flex items-center justify-between gap-2 min-w-0 mt-2">
+            <div className="flex items-center rounded-full border border-gray-200 bg-gray-50 overflow-hidden flex-shrink-0">
               <Button
                 variant="ghost"
                 size="icon"
@@ -189,7 +189,7 @@ const CartItem = ({ product, onQuantityChange, onRemove, onEditTopics }: CartIte
                 <Plus className="h-3 w-3 text-gray-600" />
               </Button>
             </div>
-            <p className="text-sm font-bold text-gray-900">{formatPrice(itemTotal)}</p>
+            <p className="text-sm font-bold text-gray-900 flex-shrink-0 whitespace-nowrap">{formatPrice(itemTotal)}</p>
           </div>
         </div>
       </motion.div>

--- a/src/features/store/components/checkout/CheckoutForm.tsx
+++ b/src/features/store/components/checkout/CheckoutForm.tsx
@@ -272,14 +272,6 @@ export const CheckoutForm = ({
       if (result.success) {
         toast.success("¡Pedido creado exitosamente!");
 
-        // Redirigir la pestaña ya abierta al WhatsApp con el mensaje del servidor.
-        const waUrl = `https://wa.me/${result.data.whatsappNumber}?text=${encodeURIComponent(result.data.whatsappMessage)}`;
-        if (waWindow) {
-          waWindow.location.href = waUrl;
-        } else if (whatsapp) {
-          window.open(waUrl, "_blank");
-        }
-
         const orderInfo = {
           orderId: result.data.orderId,
           orderNumber: result.data.orderNumber,
@@ -297,8 +289,21 @@ export const CheckoutForm = ({
           storeName: result.data.storeName,
         };
 
+        // Mostrar SIEMPRE el ticket de confirmación primero: expone un <a> nativo
+        // "Abrir WhatsApp" que funciona de forma confiable en Android e iOS (gesto
+        // real del usuario). Es el camino garantizado.
         if (onOrderComplete) {
           onOrderComplete(result.data.orderId, orderInfo);
+        }
+
+        // Auto-open best-effort en la pestaña pre-abierta de forma síncrona.
+        // En algunos navegadores móviles (p. ej. Brave/Android) la activación se
+        // pierde tras el await y wa.me cae al interstitial de descarga; por eso el
+        // botón del ticket es el fallback confiable. NO se hace un segundo
+        // window.open post-await (es el que el bloqueador de popups suele frenar).
+        if (waWindow) {
+          const waUrl = `https://wa.me/${result.data.whatsappNumber}?text=${encodeURIComponent(result.data.whatsappMessage)}`;
+          waWindow.location.href = waUrl;
         }
       } else {
         // Cerrar la pestaña en blanco si el pedido falló.

--- a/src/features/store/components/checkout/OrderTicket.tsx
+++ b/src/features/store/components/checkout/OrderTicket.tsx
@@ -545,8 +545,8 @@ export const OrderTicket: React.FC<OrderTicketProps> = ({
               style={{ color: "var(--store-primary)" }}
             />
             <p className="relative text-xs leading-relaxed" style={{ color: "#475569" }}>
-              Tu pedido fue enviado por WhatsApp. Si no se abrió automáticamente,
-              tocá el botón para reenviarlo.
+              Si WhatsApp no se abrió automáticamente, tocá el botón para abrirlo
+              y enviar tu pedido.
             </p>
           </div>
 
@@ -560,7 +560,7 @@ export const OrderTicket: React.FC<OrderTicketProps> = ({
               style={{ backgroundColor: "var(--store-primary)" }}
             >
               <MessageCircle className="w-5 h-5" />
-              Reenviar por WhatsApp
+              Abrir WhatsApp
             </a>
           ) : (
             <Button
@@ -569,7 +569,7 @@ export const OrderTicket: React.FC<OrderTicketProps> = ({
               style={{ backgroundColor: "var(--store-primary)" }}
             >
               <MessageCircle className="w-5 h-5" />
-              Reenviar por WhatsApp
+              Abrir WhatsApp
             </Button>
           )}
 


### PR DESCRIPTION
## Contexto

Cierra los hallazgos de UX reportados por usuarios reales (catálogo público y dashboard) y, en una segunda iteración, las regresiones que esos cambios introdujeron y un bug real de pérdida de datos en settings. Detalle completo en [`docs/hallazgos/fixes-ux-usuarios-2026-06-24.md`](docs/hallazgos/fixes-ux-usuarios-2026-06-24.md).

## Cambios

### Catálogo / carrito
1. **Carrito — nombre largo rompía el layout.** El `ScrollArea` de Radix (`display:table`) y, en desktop, el `Dialog` (`grid`, `min-width:auto`) expandían la fila más allá del panel, anulando el `truncate`. Fix en `Cart.tsx`: overflow nativo + `w-full min-w-0 overflow-hidden`. Verificado en mobile (Drawer) y tablet/desktop (Dialog) con nombre largo.
2. **WhatsApp checkout (Android/Brave + iOS).** La pestaña pre-abierta perdía la *user-activation* tras el `await` y `wa.me` caía al instalador. Enfoque híbrido: el ticket muestra un `<a>` nativo "Abrir WhatsApp" (confiable en ambos SO) + auto-open best-effort. Resuelve E2E-06.

### Dashboard / settings
3. **"Configuración" → 404.** Las cards apuntaban a `/dashboard/profile` (inexistente) → `/dashboard/settings`.
4. **Horarios con pestaña propia.** Nueva ruta `/dashboard/settings/schedule` (`ScheduleSettingsClient` + subitem en sidebar); se sacó de "Ubicación".
5. **Pérdida de datos al guardar (E2E-09).** Con varias instancias de `useProfile` compartiendo el store, un `setProfile` async revertía la edición en curso y se persistía el valor viejo (el toast decía "guardado"). Confirmado en CI: `Expected "1133224455" / Received "100000000"`. Fix en `useProfile.ts`: resetear el form solo si los datos cambiaron de verdad (comparación por contenido). Verificado 6/6 con seed fresco por corrida.
6. **`removeChild of null` en settings/general** (regresión de este PR): el `revalidatePath('/dashboard/settings','layout')` refrescaba el subtree en cada guardado. Fix: revalidar el catálogo público `/${storeId}`. Endurecimiento DOM: guard `parentNode` en descarga CSV; `motion.div` condicionales envueltos en `AnimatePresence`.

### CI / tests
7. **e2e estabilizado.** `02-catalog-checkout`: locator del link → `/abrir whatsapp/i`. `04-settings`: esperar la completitud del guardado (toast) antes de recargar.

## Verificación

- `npx tsc --noEmit` ✅ · `npm run lint` ✅ · `npm run test` ✅ (453 unit)
- e2e `02`+`04` contra emuladores: **12/12** (`--repeat-each=4`); `04` **6/6** con seed fresco por corrida
- **CI completo en verde** (build-test, emulators, e2e) · Vercel preview probado OK por el autor

🤖 Generated with [Claude Code](https://claude.com/claude-code)