### PR TITLE
fix(images): desactivar Image Optimization de Vercel (cuota agotada en prod)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,11 @@ const useFirebaseEmulator = process.env.NEXT_PUBLIC_USE_FIREBASE_EMULATOR === 't
 const nextConfig = {
   reactStrictMode: true,
   images: {
+    // Servimos las imágenes directo desde Firebase Storage (ya comprimidas en el upload
+    // con browser-image-compression). Evita el optimizador de Vercel y su cuota de
+    // "Image Optimization - Transformations" del plan Hobby, que al agotarse hacía fallar
+    // /_next/image y dejaba todas las imágenes en su fallback.
+    unoptimized: true,
     remotePatterns: [
       {
         protocol: 'https',


### PR DESCRIPTION
## Problema

En producción dejaron de verse **todas** las imágenes de Firebase Storage (logo, banner, fotos de productos): aparecía el fallback gris con ícono de imagen.

**Causa raíz:** Vercel agotó la cuota gratuita del plan Hobby de **Image Optimization – Transformations (5.1K / 5K)**. Al superarse el límite, el endpoint `/_next/image` deja de optimizar y falla → cada `next/image` dispara `onError` → fallback gris.

No es regresión de código ni `main` desactualizado ni `remotePatterns`. El PR #60 multiplicó las transformaciones únicas (galería con `imageUrls`, lightbox, banner+logo con `fill`, modal con varias fotos), empujando el uso por encima de 5K.

## Cambio

Una línea en `next.config.js`: `images.unoptimized: true`. `next/image` ahora sirve las URLs originales de Firebase Storage directo al navegador, sin pasar por el optimizador de Vercel. Cubre los 18 usos de `next/image`; no se tocan componentes.

Bajo impacto porque las imágenes **ya se comprimen al subirse** con `browser-image-compression` (`src/features/products/forms/product-form.tsx`).

## Verificación

1. Build/deploy.
2. En el catálogo público, DevTools → Network: las imágenes piden a `firebasestorage.googleapis.com` (200) y **ya no** hay requests a `/_next/image`.
3. Confirmar visualmente logo, banner y fotos de producto.

## Notas

- Sin optimización no hay resize por dispositivo; mitigado por la compresión en upload.
- Otros límites del plan Hobby están cerca (Fluid CPU, Edge Requests) pero no son la causa de este incidente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)